### PR TITLE
check that `@interface` specifications are obeyed by invokes

### DIFF
--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -114,6 +114,10 @@ where
     pub fn delay(&self) -> u64 {
         self.delay
     }
+
+    pub fn liveness(&self) -> &Interval<T> {
+        &self.liveness
+    }
 }
 
 impl<T> WithPos for InterfaceDef<T>
@@ -171,6 +175,11 @@ where
             outputs: self.inputs.clone(),
             ..self.clone()
         }
+    }
+
+    /// Return the interface associated with an event defined in the signature.
+    pub fn get_interface(&self, event: &Id) -> Option<&InterfaceDef<T>> {
+        self.interface_signals.iter().find(|id| id.event == event)
     }
 
     /// Returns a port associated with the signature

--- a/src/interval_checking/context.rs
+++ b/src/interval_checking/context.rs
@@ -81,6 +81,16 @@ impl<'a> ConcreteInvoke<'a> {
     ) -> FilamentResult<ast::Interval> {
         self.resolve_port::<false>(port)
     }
+
+    pub fn get_sig(&self) -> &ast::Signature {
+        match &self {
+            ConcreteInvoke::Concrete { sig, .. } => sig,
+            ConcreteInvoke::This { sig } => sig,
+            ConcreteInvoke::Fsm { .. } => {
+                unreachable!("Called get_sig on FSM instance")
+            }
+        }
+    }
 }
 
 type FactMap = Vec<ast::Constraint>;
@@ -174,6 +184,8 @@ impl<'a> Context<'a> {
         }
     }
 
+    /// Add assignments that must be present to make a low-level invoke work
+    /// correctly.
     pub fn add_remaning_assigns(
         &mut self,
         bind: ast::Id,
@@ -191,6 +203,8 @@ impl<'a> Context<'a> {
         Ok(())
     }
 
+    /// Track event bindings for each instance.
+    /// This is used for the disjointness check.
     pub fn add_event_binds(
         &mut self,
         instance: ast::Id,
@@ -203,6 +217,7 @@ impl<'a> Context<'a> {
             .push((pos, binds));
     }
 
+    /// Remove a remaining assignment from an invoke
     pub fn remove_remaning_assign(
         &mut self,
         port: &ast::Port,

--- a/tests/errors/invoke-max-trig-too-often.expect
+++ b/tests/errors/invoke-max-trig-too-often.expect
@@ -1,0 +1,13 @@
+---STDERR---
+error: Instance requires event to pulse no more than every 5 cycles but provided event may pulse every 3 cycles
+   ┌─ tests/errors/invoke-max-trig-too-often.fil:12:3
+   │
+ 3 │     @interface<G, 5> go_G: 1,
+   │     ------------------------ Interface requires event to trigger once in 5 cycles
+   ·
+ 9 │   @interface<L, 3> go_L: 1
+   │   ------------------------ Provided event may trigger every 3 cycles
+   ·
+12 │   m0 := invoke M<max(T+1, L+4)>;
+   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Event binding violates @interface specification
+

--- a/tests/errors/invoke-max-trig-too-often.fil
+++ b/tests/errors/invoke-max-trig-too-often.fil
@@ -1,0 +1,13 @@
+extern "dummy.sv" {
+  component Mult<G>(
+    @interface<G, 5> go_G: 1,
+  ) -> ();
+}
+
+component Main<T, L>(
+  @interface<T, 6> go_T: 1,
+  @interface<L, 3> go_L: 1
+) -> () {
+  M := new Mult;
+  m0 := invoke M<max(T+1, L+4)>;
+}

--- a/tests/errors/invoke-trig-too-often.expect
+++ b/tests/errors/invoke-trig-too-often.expect
@@ -1,0 +1,13 @@
+---STDERR---
+error: Instance requires event to pulse no more than every 5 cycles but provided event may pulse every 3 cycles
+  ┌─ tests/errors/invoke-trig-too-often.fil:9:3
+  │
+3 │     @interface<G, 5> go_G: 1,
+  │     ------------------------ Interface requires event to trigger once in 5 cycles
+  ·
+7 │ component Main<T>(@interface<T, 3> go_T: 1) -> () {
+  │                   ------------------------ Provided event may trigger every 3 cycles
+8 │   M := new Mult;
+9 │   m0 := invoke M<T+1>;
+  │   ^^^^^^^^^^^^^^^^^^^^ Event binding violates @interface specification
+

--- a/tests/errors/invoke-trig-too-often.fil
+++ b/tests/errors/invoke-trig-too-often.fil
@@ -1,0 +1,10 @@
+extern "dummy.sv" {
+  component Mult<G>(
+    @interface<G, 5> go_G: 1,
+  ) -> ();
+}
+
+component Main<T>(@interface<T, 3> go_T: 1) -> () {
+  M := new Mult;
+  m0 := invoke M<T+1>;
+}


### PR DESCRIPTION
An `@interface` specification requires that the binding provided to it may not pulse more often than the delay on the `@interface` itself