### PR TITLE
Use hack to define shorter delay for register

### DIFF
--- a/primitives/core.fil
+++ b/primitives/core.fil
@@ -1,14 +1,15 @@
 extern "core.sv" {
   // A register that can extend the lifetime of a signal to any required length.
-  component Latch<G, L>(
+  component Latch<G, S, L>(
     clk: 1,
     reset: 1,
     // -- base ports --
-    @interface[G, L] write_en: 1,
+    @interface[G, G+1] write_en: 1,
+    @interface[S, L] _go_L: 1, // unused
     @[G, G+1] in: 32
   ) -> (
-    @[G+1, L] out: 32
-  ) where L > G+1;
+    @[S, L] out: 32
+  ) where S = G+1, L > S;
 }
 
 extern "binary.sv" {
@@ -40,8 +41,8 @@ component Mult<G>(
   LL := new Latch;
   LR := new Latch;
 
-  ll := LL<G, G+3>(left);
-  lr := LR<G, G+3>(right);
+  ll := LL<G, G+1, G+3>(left);
+  lr := LR<G, G+1, G+3>(right);
 
   M := new MultComb;
   m := M<G+2>(ll.out, lr.out);

--- a/primitives/core.fil
+++ b/primitives/core.fil
@@ -5,7 +5,7 @@ extern "core.sv" {
     reset: 1,
     // -- base ports --
     @interface[G, G+1] write_en: 1,
-    @interface[S, L] _go_L: 1, // unused
+    @interface[S, L] _go_S: 1, // unused
     @[G, G+1] in: 32
   ) -> (
     @[S, L] out: 32

--- a/primitives/core.sv
+++ b/primitives/core.sv
@@ -4,6 +4,7 @@ module Latch (
   input wire clk,
   input wire reset,
   input wire write_en,
+  input wire _go_S, // unused
   input wire logic [31:0] in,
   output logic [31:0] out
 );

--- a/src/interval_checking/checker.rs
+++ b/src/interval_checking/checker.rs
@@ -134,7 +134,15 @@ fn check_invoke_binds<'a>(
     );
 
     let sig = ctx.get_instance(&invoke.instance)?;
-    let binding = sig.binding(&invoke.abstract_vars)?;
+    let binding = sig.binding(&invoke.abstract_vars).map_err(|err| {
+        err.add_note(
+            format!(
+                "Invocation provides {} events",
+                invoke.abstract_vars.len()
+            ),
+            invoke.copy_span(),
+        )
+    })?;
     let this_sig = ctx.get_invoke(&THIS.into())?.get_sig();
     let mut constraints = vec![];
 

--- a/tests/check/max.fil
+++ b/tests/check/max.fil
@@ -21,8 +21,8 @@ component Max_mult_add<G, L>(
   m1 := M1<L>(c, d);
 
   // Latch the signals till both outputs are available.
-  m0_l := L1<G+2, max(G+4, L+4) + 1>(m0.out);
-  m1_l := L0<L+2, max(G+4, L+4) + 1>(m1.out);
+  m0_l := L1<G+2, G+3, max(G+4, L+4) + 1>(m0.out);
+  m1_l := L0<L+2, L+3, max(G+4, L+4) + 1>(m1.out);
   a0 := A<max(G+4, L+4)>(m0_l.out, m1_l.out);
 
   out = a0.out;

--- a/tests/check/merge.fil
+++ b/tests/check/merge.fil
@@ -31,7 +31,7 @@ component main<G>(
   M := new Merge;
 
   // Intentially make the latch exist longer than needed.
-  l0 := L<G, G+4>(in);
+  l0 := L<G, G+1, G+4>(in);
   m0 := M<G, G+1, G+3>(in, l0.out);
 
   out = m0.out;

--- a/tests/check/pipeline-with-ii-1.fil
+++ b/tests/check/pipeline-with-ii-1.fil
@@ -1,0 +1,29 @@
+import "primitives/core.fil";
+
+/// Implementation of a multiplier with initiation interval 1 and latency 3
+component FastMult<G>(
+  @interface[G, G+1] go_G: 1,
+  @[G, G+1] left: 32,
+  @[G, G+1] right: 32,
+) -> (
+  @[G+3, G+4] out: 32,
+) {
+  // First stage, register the inputs
+  L := new Latch;
+  R := new Latch;
+  l := L<G, G+1, G+2>(left);
+  r := R<G, G+1, G+2>(right);
+
+  // Second stage, perform the computation and save it
+  M := new MultComb;
+  m := M<G+1>(l.out, r.out);
+  OutTmp := new Latch;
+  ot := OutTmp<G+1, G+2, G+3>(m.out);
+
+  // Third stage, forward the value from temp out to out register
+  Out := new Latch;
+  final := Out<G+2, G+3, G+4>(ot.out);
+
+  // Connect the output to the out register
+  out = final.out;
+}

--- a/tests/check/reg-dyanmic-use.fil
+++ b/tests/check/reg-dyanmic-use.fil
@@ -5,6 +5,6 @@ component Main<G, L>(
   @interface[L, L+1] go_T: 1,
 ) -> () where L > G+1, G+5 > L {
   L := new Latch;
-  l0 := L<G, L>(10);
-  l1 := L<G+5, G+7>(10);
+  l0 := L<G, G+1, L>(10);
+  l1 := L<G+5, G+6, G+7>(10);
 }

--- a/tests/errors/unprovable-cons.fil
+++ b/tests/errors/unprovable-cons.fil
@@ -12,7 +12,7 @@ component Main<G, L>(
 ) {
   L := new Latch;
   M := new Mult;
-  l0 := L<G, L+1>(left);
+  l0 := L<G, G+1, L+1>(left);
   m0 := M<L>(l0.out, right);
   out = m0.out;
 }

--- a/tests/errors/unsatisfied-requirement.expect
+++ b/tests/errors/unsatisfied-requirement.expect
@@ -7,8 +7,8 @@ error: Cannot prove constraint G+1 >= G+2
 10 │   m0 := M<G+1>(left, right);
    │                ^^^^ Source is available for [G, G+1]
    │
-   ┌─ ./primitives/core.fil:35:3
+   ┌─ ./primitives/core.fil:36:3
    │
-35 │   @[G, G+1] left: 32,
+36 │   @[G, G+1] left: 32,
    │   ------------------ Destination's requirement [G+1, G+2]
 


### PR DESCRIPTION
Defines another event variable so that we can specify the delay of the register more precisely. The syntax and usage is kind of annoying so hopefully we can add some sugar for it in the future.
