### PR TITLE
Solver improvements

### DIFF
--- a/src/core/constraint.rs
+++ b/src/core/constraint.rs
@@ -221,6 +221,7 @@ impl Constraint {
         }
     }
 
+    /// All expressions used in this constraint
     pub fn exprs(&self) -> Vec<&Expr> {
         match self {
             Constraint::Base { base } => {

--- a/src/utils/solver.rs
+++ b/src/utils/solver.rs
@@ -312,12 +312,15 @@ impl FilSolver {
         vars: &[core::Id],
     ) -> Option<String> {
         let sexp = fact.into();
-        self.s.push(1).unwrap();
+        // Generate an activation literal
+        let act = self.s.get_actlit().unwrap();
         let formula = format!("(not {})", sexp);
         log::trace!("Assert {}", formula);
-        self.s.assert(formula).unwrap();
+        self.s.assert_act(&act, formula).unwrap();
         // Check that the assertion was unsatisfiable
-        let unsat = !self.s.check_sat().unwrap();
+        let unsat = !self.s.check_sat_act(Some(&act)).unwrap();
+
+        // If the assignment was not unsatisfiable, attempt to generate an assignment
         let assigns = if !unsat {
             log::trace!("MODEL: {:?}", self.s.get_model().unwrap());
             // If there are no relevant variables, we can't show a model
@@ -338,7 +341,7 @@ impl FilSolver {
         } else {
             None
         };
-        self.s.pop(1).unwrap();
+        self.s.de_actlit(act).unwrap();
         assigns
     }
 }

--- a/tests/errors/conflicting-use.expect
+++ b/tests/errors/conflicting-use.expect
@@ -12,6 +12,5 @@ error: Cannot prove constraint 1 >= 2
 9 │   m1 := M<G+1>(30, 40);
   │   --------------------- invocation starts at `G+1'
   │
-  = assignment violates constraint: G=0
 
 Compilation failed with 1 errors.

--- a/tests/errors/dynamic-share.expect
+++ b/tests/errors/dynamic-share.expect
@@ -10,7 +10,6 @@ error: Cannot prove constraint L = G
    │           - invocation uses event G
    │
    = invocations of instance use multiple events in invocations: L and G. Sharing using multiple events is not supported.
-   = assignment violates constraint: G=1, L=0
 
 error: Cannot prove constraint |L - G| >= 1
    ┌─ tests/errors/dynamic-share.fil:3:25
@@ -23,7 +22,6 @@ error: Cannot prove constraint |L - G| >= 1
 13 │   m0 := M<G>(a, b);
    │   ----------------- invocation starts at `G'
    │
-   = assignment violates constraint: G=0, L=0
 
 error: Cannot prove constraint |L - G| >= 1
    ┌─ tests/errors/dynamic-share.fil:3:25
@@ -36,7 +34,6 @@ error: Cannot prove constraint |L - G| >= 1
 13 │   m0 := M<G>(a, b);
    │   ----------------- invocation starts at `G+1'
    │
-   = assignment violates constraint: G=0, L=0
 
 error: Cannot prove constraint |G - L| >= 1
    ┌─ tests/errors/dynamic-share.fil:13:3
@@ -49,7 +46,6 @@ error: Cannot prove constraint |G - L| >= 1
 13 │   m0 := M<G>(a, b);
    │   ^^^^^^^^^^^^^^^^^ invocation starts at `G'
    │
-   = assignment violates constraint: G=0, L=0
 
 error: Cannot prove constraint |G - L| >= 1
    ┌─ tests/errors/dynamic-share.fil:3:25
@@ -62,7 +58,6 @@ error: Cannot prove constraint |G - L| >= 1
 13 │   m0 := M<G>(a, b);
    │   ----------------- invocation starts at `G+1'
    │
-   = assignment violates constraint: G=0, L=0
 
 error: Cannot prove constraint 3 >= max(L+1) - min(G)
    ┌─ tests/errors/dynamic-share.fil:3:25

--- a/tests/errors/invalid-interface-input.expect
+++ b/tests/errors/invalid-interface-input.expect
@@ -10,6 +10,5 @@ error: Cannot prove constraint 1 >= 2
 6 │     @[L, L+2] in2: 32,
   │     ^^^^^^^^^^^^^^^^^ signal lasts for 2 cycle(s)
   │
-  = assignment violates constraint: G=0, L=0
 
 Compilation failed with 1 errors.

--- a/tests/errors/invalid-interface-output.expect
+++ b/tests/errors/invalid-interface-output.expect
@@ -10,6 +10,5 @@ error: Cannot prove constraint 1 >= 2
 6 │     @[G+2, G+4] out: 1,
   │     ------------------ signal lasts for 2 cycle(s)
   │
-  = assignment violates constraint: G=0, L=0
 
 Compilation failed with 1 errors.

--- a/tests/errors/invoke-trig-too-often.expect
+++ b/tests/errors/invoke-trig-too-often.expect
@@ -13,6 +13,5 @@ error: Cannot prove constraint 3 >= 5
 9 │   m0 := invoke M<T+1>;
   │   ^^^^^^^^^^^^^^^^^^^^ event provided to invoke triggers too often
   │
-  = assignment violates constraint: T=0
 
 Compilation failed with 1 errors.

--- a/tests/errors/poly-mismatch.expect
+++ b/tests/errors/poly-mismatch.expect
@@ -12,7 +12,7 @@ error: Cannot prove constraint G+#W >= G+#N
 11 │     @[G, L] left: #WIDTH,
    │             ---- destination's requirement @[G+#W, G+#W+1]
    │
-   = assignment violates constraint: G=0, W=1, N=2
+   = assignment violates constraint: W=1, N=2
 
 error: Cannot prove constraint G+#N+1 >= G+#W+1
    ┌─ tests/errors/poly-mismatch.fil:17:28
@@ -25,7 +25,7 @@ error: Cannot prove constraint G+#N+1 >= G+#W+1
 11 │     @[G, L] left: #WIDTH,
    │             ---- destination's requirement @[G+#W, G+#W+1]
    │
-   = assignment violates constraint: G=0, W=3, N=2
+   = assignment violates constraint: N=2, W=3
 
 error: Cannot prove constraint G+#W >= G+#N
    ┌─ tests/errors/poly-mismatch.fil:17:35
@@ -38,7 +38,7 @@ error: Cannot prove constraint G+#W >= G+#N
 12 │     @[G, L] right: #WIDTH,
    │             ----- destination's requirement @[G+#W, G+#W+1]
    │
-   = assignment violates constraint: G=0, W=3, N=4
+   = assignment violates constraint: W=3, N=4
 
 error: Cannot prove constraint G+#N+1 >= G+#W+1
    ┌─ tests/errors/poly-mismatch.fil:17:35
@@ -51,7 +51,7 @@ error: Cannot prove constraint G+#N+1 >= G+#W+1
 12 │     @[G, L] right: #WIDTH,
    │             ----- destination's requirement @[G+#W, G+#W+1]
    │
-   = assignment violates constraint: G=0, W=5, N=4
+   = assignment violates constraint: N=4, W=5
 
 error: Cannot prove constraint G+#N >= G+#W
    ┌─ tests/errors/poly-mismatch.fil:18:11
@@ -61,7 +61,7 @@ error: Cannot prove constraint G+#N >= G+#W
    │     │      
    │     destination's requirement @[G+#N, G+#N+1]
    │
-   = assignment violates constraint: G=0, W=5, N=4
+   = assignment violates constraint: N=4, W=5
 
 error: Cannot prove constraint G+#W+1 >= G+#N+1
    ┌─ tests/errors/poly-mismatch.fil:18:11
@@ -71,7 +71,7 @@ error: Cannot prove constraint G+#W+1 >= G+#N+1
    │     │      
    │     destination's requirement @[G+#N, G+#N+1]
    │
-   = assignment violates constraint: G=0, W=5, N=6
+   = assignment violates constraint: W=5, N=6
 
 error: Cannot prove constraint G+3 >= G+5
    ┌─ tests/errors/poly-mismatch.fil:25:11
@@ -81,6 +81,5 @@ error: Cannot prove constraint G+3 >= G+5
    │     │      
    │     destination's requirement @[G+4, G+5]
    │
-   = assignment violates constraint: G=0
 
 Compilation failed with 7 errors.

--- a/tests/errors/poly-mismatch.expect
+++ b/tests/errors/poly-mismatch.expect
@@ -25,7 +25,7 @@ error: Cannot prove constraint G+#N+1 >= G+#W+1
 11 │     @[G, L] left: #WIDTH,
    │             ---- destination's requirement @[G+#W, G+#W+1]
    │
-   = assignment violates constraint: N=2, W=3
+   = assignment violates constraint: N=0, W=1
 
 error: Cannot prove constraint G+#W >= G+#N
    ┌─ tests/errors/poly-mismatch.fil:17:35
@@ -38,7 +38,7 @@ error: Cannot prove constraint G+#W >= G+#N
 12 │     @[G, L] right: #WIDTH,
    │             ----- destination's requirement @[G+#W, G+#W+1]
    │
-   = assignment violates constraint: W=3, N=4
+   = assignment violates constraint: W=1, N=2
 
 error: Cannot prove constraint G+#N+1 >= G+#W+1
    ┌─ tests/errors/poly-mismatch.fil:17:35
@@ -51,17 +51,7 @@ error: Cannot prove constraint G+#N+1 >= G+#W+1
 12 │     @[G, L] right: #WIDTH,
    │             ----- destination's requirement @[G+#W, G+#W+1]
    │
-   = assignment violates constraint: N=4, W=5
-
-error: Cannot prove constraint G+#N >= G+#W
-   ┌─ tests/errors/poly-mismatch.fil:18:11
-   │
-18 │     out = a.out;
-   │     ---   ^^^^^ source is available for @[G+#W, G+#W+1]
-   │     │      
-   │     destination's requirement @[G+#N, G+#N+1]
-   │
-   = assignment violates constraint: N=4, W=5
+   = assignment violates constraint: N=0, W=1
 
 error: Cannot prove constraint G+#W+1 >= G+#N+1
    ┌─ tests/errors/poly-mismatch.fil:18:11
@@ -71,7 +61,17 @@ error: Cannot prove constraint G+#W+1 >= G+#N+1
    │     │      
    │     destination's requirement @[G+#N, G+#N+1]
    │
-   = assignment violates constraint: W=5, N=6
+   = assignment violates constraint: W=1, N=2
+
+error: Cannot prove constraint G+#N >= G+#W
+   ┌─ tests/errors/poly-mismatch.fil:18:11
+   │
+18 │     out = a.out;
+   │     ---   ^^^^^ source is available for @[G+#W, G+#W+1]
+   │     │      
+   │     destination's requirement @[G+#N, G+#N+1]
+   │
+   = assignment violates constraint: N=0, W=1
 
 error: Cannot prove constraint G+3 >= G+5
    ┌─ tests/errors/poly-mismatch.fil:25:11

--- a/tests/errors/unprovable-cons.expect
+++ b/tests/errors/unprovable-cons.expect
@@ -12,7 +12,6 @@ error: Cannot prove constraint L+1 > G+1
 14 │   l0 := L<G, L+1>(left);
    │   ---------------------- component's where clause constraints must be satisfied
    │
-   = assignment violates constraint: G=0, L=0
 
 error: Cannot prove constraint |L - G| >= 1
    ┌─ ./primitives/./state.fil:7:5
@@ -28,7 +27,6 @@ error: Cannot prove constraint |L - G| >= 1
 14 │   l0 := L<G, L+1>(left);
    │   ---------------------- component's where clause constraints must be satisfied
    │
-   = assignment violates constraint: G=0, L=0
 
 error: Cannot prove constraint |L - G| >= 1
   ┌─ tests/errors/unprovable-cons.fil:8:3
@@ -39,7 +37,6 @@ error: Cannot prove constraint |L - G| >= 1
 8 │   @[G, G+1] left: 32,
   │   ^^^^^^^^^^^^^^^^^^ signal lasts for 1 cycle(s)
   │
-  = assignment violates constraint: G=0, L=0
 
 error: Cannot prove constraint L+1 > G+1
    ┌─ tests/errors/unprovable-cons.fil:14:3
@@ -47,7 +44,6 @@ error: Cannot prove constraint L+1 > G+1
 14 │   l0 := L<G, L+1>(left);
    │   ^^^^^^^^^^^^^^^^^^^^^^ component's where clause constraints must be satisfied
    │
-   = assignment violates constraint: G=0, L=0
 
 error: Multiple errors encountered
    ┌─ tests/errors/unprovable-cons.fil:15:9
@@ -57,7 +53,6 @@ error: Multiple errors encountered
    │   │      
    │   destination's requirement @[L+2, L+3]
    │
-   = assignment violates constraint: G=2, L=0
    = Cannot prove constraint L+2 >= G+1
    = Cannot prove constraint L+1 >= L+3
 

--- a/tests/errors/unsatisfied-guarantee.expect
+++ b/tests/errors/unsatisfied-guarantee.expect
@@ -9,6 +9,5 @@ error: Cannot prove constraint G+1 >= G+4
    │   │      
    │   destination's requirement @[G+3, G+4]
    │
-   = assignment violates constraint: G=0
 
 Compilation failed with 1 errors.

--- a/tests/errors/unsatisfied-requirement.expect
+++ b/tests/errors/unsatisfied-requirement.expect
@@ -12,7 +12,6 @@ error: Cannot prove constraint G+1 >= G+2
 25 │     @[G, L] left: #WIDTH,
    │             ---- destination's requirement @[G+1, G+2]
    │
-   = assignment violates constraint: G=0
 
 error: Cannot prove constraint G+2 >= G+4
    ┌─ tests/errors/unsatisfied-requirement.fil:12:9
@@ -22,6 +21,5 @@ error: Cannot prove constraint G+2 >= G+4
    │   │      
    │   destination's requirement @[G+3, G+4]
    │
-   = assignment violates constraint: G=0
 
 Compilation failed with 2 errors.


### PR DESCRIPTION
Only show relevant variables when generating assignments for a failing constraints. Also use rsmt2's activation literals trick.