### PR TITLE
Monomorphize bundles

### DIFF
--- a/evaluation/iterative-divider/harness.fil
+++ b/evaluation/iterative-divider/harness.fil
@@ -21,13 +21,13 @@ comp main<G: 11>(
 ) -> (
   @[G, G+1] comb_noshare: 8,
   @[G+9, G+10] verilog: 8,
-  @[G+7, G+8] share: 8,
-  @[G+7, G+8] pipe: 8,
+  @[G+8, G+9] share: 8,
+  @[G+8, G+9] pipe: 8,
 ) {
   d := new IterDiv[8]<G>(left, right);
-  id := new CombNoShareIterDiv<G>(left, right);
-  s := new ShareIterDiv<G>(left, right);
-  pipe := new PipeIterDiv<G>(left, right);
+  id := new CombNoShareIterDiv[8, 7]<G>(left, right);
+  s := new ShareIterDiv[8, 7]<G>(left, right);
+  pipe := new PipeIterDiv[8, 7]<G>(left, right);
   verilog = d.out_quotient;
   comb_noshare = id.quotient;
   share = s.quotient;

--- a/evaluation/iterative-divider/harness.fil
+++ b/evaluation/iterative-divider/harness.fil
@@ -14,6 +14,26 @@ extern "iter-div.sv" {
   ) where #W > 0;
 }
 
+comp DiffTest[#W, #L]<G: #W+1>(
+  @interface[G] go: 1,
+  @[G, G+1] left: #W,
+  @[G, G+#W+1] right: #W,
+) -> (
+  @[G, G+1] comb_noshare: #W,
+  @[G+#W+1, G+#W+2] verilog: #W,
+  @[G+#W, G+#W+1] share: #W,
+  @[G+#W, G+#W+1] pipe: #W,
+) where #W > 0, #W = #L + 1 {
+  d := new IterDiv[#W]<G>(left, right);
+  id := new CombNoShareIterDiv[#W, #L]<G>(left, right);
+  s := new ShareIterDiv[#W, #L]<G>(left, right);
+  pipe := new PipeIterDiv[#W, #L]<G>(left, right);
+  verilog = d.out_quotient;
+  comb_noshare = id.quotient;
+  share = s.quotient;
+  pipe = pipe.quotient;
+}
+
 comp main<G: 11>(
   @interface[G] go: 1,
   @[G, G+1] left: 8,
@@ -24,12 +44,9 @@ comp main<G: 11>(
   @[G+8, G+9] share: 8,
   @[G+8, G+9] pipe: 8,
 ) {
-  d := new IterDiv[8]<G>(left, right);
-  id := new CombNoShareIterDiv[8, 7]<G>(left, right);
-  s := new ShareIterDiv[8, 7]<G>(left, right);
-  pipe := new PipeIterDiv[8, 7]<G>(left, right);
-  verilog = d.out_quotient;
-  comb_noshare = id.quotient;
-  share = s.quotient;
-  pipe = pipe.quotient;
+  d := new DiffTest[8, 7]<G>(left, right);
+  verilog = d.verilog;
+  comb_noshare = d.comb_noshare;
+  share = d.share;
+  pipe = d.pipe;
 }

--- a/evaluation/iterative-divider/iter-div.fil
+++ b/evaluation/iterative-divider/iter-div.fil
@@ -62,125 +62,93 @@ comp Init[#W]<G: 1>(
   quotient = q_slice.out;
 }
 
-comp CombNoShareIterDiv<G: 1>(
+comp CombNoShareIterDiv[#W, #L]<G: 1>(
   @interface[G] go: 1,
-  @[G, G+1] left: 8,
-  @[G, G+1] right: 8
+  @[G, G+1] left: #W,
+  @[G, G+1] right: #W,
 ) -> (
-  @[G, G+1] quotient: 8
-) {
-  i := new Init[8]<G>(left);
-  s0 := new Next[8, 7]<G>(i.acc, right, i.quotient);
-  // Iterate 7 more times
-  s1 := new Next[8, 7]<G>(s0.acc_next, right, s0.quotient_next);
-  s2 := new Next[8, 7]<G>(s1.acc_next, right, s1.quotient_next);
-  s3 := new Next[8, 7]<G>(s2.acc_next, right, s2.quotient_next);
-  s4 := new Next[8, 7]<G>(s3.acc_next, right, s3.quotient_next);
-  s5 := new Next[8, 7]<G>(s4.acc_next, right, s4.quotient_next);
-  s6 := new Next[8, 7]<G>(s5.acc_next, right, s5.quotient_next);
-  s7 := new Next[8, 7]<G>(s6.acc_next, right, s6.quotient_next);
-  quotient = s7.quotient_next;
+  @[G, G+1] quotient: #W
+) where #W > 0, #W = #L + 1 {
+  bundle acc[#W+1]: for<#i> @[G, G+1] #W+1;
+  bundle quotient_next[#W+1]: for<#i> @[G, G+1] #W;
+
+  // Initialize the accumulator and quotient
+  init := new Init[#W]<G>(left);
+  acc{0} = init.acc;
+  quotient_next{0} = init.quotient;
+
+  for #i in 0..#W {
+    s := new Next[#W, #L]<G>(acc{#i}, right, quotient_next{#i});
+    acc{#i+1} = s.acc_next;
+    quotient_next{#i+1} = s.quotient_next;
+  }
+
+  quotient = quotient_next{#W};
 }
 
-comp ShareIterDiv<G: 7>(
+comp ShareIterDiv[#W, #L]<G: #W>(
   @interface[G] go: 1,
-  @[G, G+1] left: 8,
-  @[G, G+1] right: 8,
+  @[G, G+1] left: #W,
+  @[G, G+1] right: #W,
 ) -> (
-  @[G+7, G+8] quotient: 8
-) {
-  i := new Init[8]<G>(left);
-  s0 := new Next[8, 7]<G>(i.acc, right, i.quotient);
+  @[G+#W, G+#W+1] quotient: #W
+) where #W > 0, #W = #L + 1 {
+  bundle acc[#W+1]: for<#i> @[G+#i, G+#i+1] #W+1;
+  bundle qn[#W+1]: for<#i> @[G+#i, G+#i+1] #W;
+  bundle r[#W+1]: for<#i> @[G+#i, G+#i+1] #W;
 
-  N := new Next[8, 7];
-  Acc := new Register[9];
-  QN := new Register[8];
-  R := new Register[8];
+  i := new Init[#W]<G>(left);
+  acc{0} = i.acc;
+  qn{0} = i.quotient;
+  r{0} = right;
 
-  acc0 := Acc<G, G+2>(s0.acc_next);
-  qn0 := QN<G, G+2>(s0.quotient_next);
-  r0 := R<G, G+2>(right);
-  s1 := N<G+1>(acc0.out, r0.out, qn0.out);
+  N := new Next[#W, #L];
+  Acc := new Delay[#W+1];
+  QN := new Delay[#W];
+  R := new Delay[#W];
 
-  acc1 := Acc<G+1, G+3>(s1.acc_next);
-  qn1 := QN<G+1, G+3>(s1.quotient_next);
-  r1 := R<G+1, G+3>(r0.out);
-  s2 := N<G+2>(acc1.out, r1.out, qn1.out);
-
-  acc2 := Acc<G+2, G+4>(s2.acc_next);
-  qn2 := QN<G+2, G+4>(s2.quotient_next);
-  r2 := R<G+2, G+4>(r1.out);
-  s3 := N<G+3>(acc2.out, r2.out, qn2.out);
-
-  acc3 := Acc<G+3, G+5>(s3.acc_next);
-  qn3 := QN<G+3, G+5>(s3.quotient_next);
-  r3 := R<G+3, G+5>(r2.out);
-  s4 := N<G+4>(acc3.out, r3.out, qn3.out);
-
-  acc4 := Acc<G+4, G+6>(s4.acc_next);
-  qn4 := QN<G+4, G+6>(s4.quotient_next);
-  r4 := R<G+4, G+6>(r3.out);
-  s5 := N<G+5>(acc4.out, r4.out, qn4.out);
-
-  acc5 := Acc<G+5, G+7>(s5.acc_next);
-  qn5 := QN<G+5, G+7>(s5.quotient_next);
-  r5 := R<G+5, G+7>(r4.out);
-  s6 := N<G+6>(acc5.out, r5.out, qn5.out);
-
-  acc6 := Acc<G+6, G+8>(s6.acc_next);
-  qn6 := QN<G+6, G+8>(s6.quotient_next);
-  r6 := R<G+6, G+8>(r5.out);
-  s7 := N<G+7>(acc6.out, r6.out, qn6.out);
+  for #i in 0..#W {
+    s := N<G+#i>(acc{#i}, r{#i}, qn{#i});
+    acc_reg := Acc<G+#i>(s.acc_next);
+    acc{#i+1} = acc_reg.out;
+    qn_reg := QN<G+#i>(s.quotient_next);
+    qn{#i+1} = qn_reg.out;
+    r_reg := R<G+#i>(r{#i});
+    r{#i+1} = r_reg.out;
+  }
 
   // Iterate 7 more times
-  quotient = s7.quotient_next;
+  quotient = qn{#W};
 }
 
-comp PipeIterDiv<G: 1>(
+comp PipeIterDiv[#W, #L]<G: 1>(
   @interface[G] go: 1,
-  @[G, G+1] left: 8,
-  @[G, G+1] right: 8,
+  @[G, G+1] left: #W,
+  @[G, G+1] right: #W,
 ) -> (
-  @[G+7, G+8] quotient: 8
-) {
-  i := new Init[8]<G>(left);
-  s0 := new Next[8, 7]<G>(i.acc, right, i.quotient);
+  @[G+#W, G+#W+1] quotient: #W
+) where #W > 0, #W = #L + 1 {
+  bundle acc[#W+1]: for<#i> @[G+#i, G+#i+1] #W+1;
+  bundle qn[#W+1]: for<#i> @[G+#i, G+#i+1] #W;
+  bundle r[#W+1]: for<#i> @[G+#i, G+#i+1] #W;
 
-  acc0 := new Register[9]<G, G+2>(s0.acc_next);
-  qn0 := new Register[8]<G, G+2>(s0.quotient_next);
-  r0 := new Register[8]<G, G+2>(right);
-  s1 := new Next[8, 7]<G+1>(acc0.out, r0.out, qn0.out);
+  i := new Init[#W]<G>(left);
+  acc{0} = i.acc;
+  qn{0} = i.quotient;
+  r{0} = right;
 
-  acc1 := new Register[9]<G+1, G+3>(s1.acc_next);
-  qn1 := new Register[8]<G+1, G+3>(s1.quotient_next);
-  r1 := new Register[8]<G+1, G+3>(r0.out);
-  s2 := new Next[8, 7]<G+2>(acc1.out, r1.out, qn1.out);
+  for #i in 0..#W {
+    s := new Next[#W, #L]<G+#i>(acc{#i}, r{#i}, qn{#i});
+    acc_reg := new Delay[#W+1]<G+#i>(s.acc_next);
+    acc{#i+1} = acc_reg.out;
+    qn_reg := new Delay[#W]<G+#i>(s.quotient_next);
+    qn{#i+1} = qn_reg.out;
+    r_reg := new Delay[#W]<G+#i>(r{#i});
+    r{#i+1} = r_reg.out;
+  }
 
-  acc2 := new Register[9]<G+2, G+4>(s2.acc_next);
-  qn2 := new Register[8]<G+2, G+4>(s2.quotient_next);
-  r2 := new Register[8]<G+2, G+4>(r1.out);
-  s3 := new Next[8, 7]<G+3>(acc2.out, r2.out, qn2.out);
+  // This unecessarily registers the last value of the quotient increasing the
+  // latency by 1 increasing the latency by 1.
 
-  acc3 := new Register[9]<G+3, G+5>(s3.acc_next);
-  qn3 := new Register[8]<G+3, G+5>(s3.quotient_next);
-  r3 := new Register[8]<G+3, G+5>(r2.out);
-  s4 := new Next[8, 7]<G+4>(acc3.out, r3.out, qn3.out);
-
-  acc4 := new Register[9]<G+4, G+6>(s4.acc_next);
-  qn4 := new Register[8]<G+4, G+6>(s4.quotient_next);
-  r4 := new Register[8]<G+4, G+6>(r3.out);
-  s5 := new Next[8, 7]<G+5>(acc4.out, r4.out, qn4.out);
-
-  acc5 := new Register[9]<G+5, G+7>(s5.acc_next);
-  qn5 := new Register[8]<G+5, G+7>(s5.quotient_next);
-  r5 := new Register[8]<G+5, G+7>(r4.out);
-  s6 := new Next[8, 7]<G+6>(acc5.out, r5.out, qn5.out);
-
-  acc6 := new Register[9]<G+6, G+8>(s6.acc_next);
-  qn6 := new Register[8]<G+6, G+8>(s6.quotient_next);
-  r6 := new Register[8]<G+6, G+8>(r5.out);
-  s7 := new Next[8, 7]<G+7>(acc6.out, r6.out, qn6.out);
-
-  // Iterate 7 more times
-  quotient = s7.quotient_next;
+  quotient = qn{#W};
 }

--- a/primitives/state.fil
+++ b/primitives/state.fil
@@ -41,14 +41,15 @@ extern "state.sv" {
   );
 }
 
-// A component that delays `in` by N cycles. Uses the Delay component under the
-// hood.
+// A component that delays `in` by N cycles.
+// Uses the Delay component under the hood.
 comp Shift[#W, #N]<G: 1>(
     @[G, G+1] in: #W
 ) -> (
     @[G+#N, G+#N+1] out: #W
 ) {
     bundle f[#N+1]: for<#i> @[G+#i, G+#i+1] #W;
+
     f{0} = in;
     for #i in 0..#N {
         d := new Delay[#W]<G+#i>(f{#i});

--- a/primitives/state.fil
+++ b/primitives/state.fil
@@ -20,16 +20,6 @@ extern "state.sv" {
     @[G+1, G+2] out: #WIDTH,
   );
 
-  // A component that delays `in` by N cycles. Uses the Delay component under the
-  // hood.
-  comp Shift[#WIDTH, #N]<G: 1>(
-    clk: 1,
-    reset: 1,
-    @[G, G+1] in: #WIDTH,
-  ) -> (
-    @[G+#N, G+#N+1] out: #WIDTH,
-  );
-
   // A comp that allows access to its previous stored value.
   // Backend by a simple register
   comp Prev[#WIDTH, #SAFE]<G: 1>(
@@ -49,4 +39,20 @@ extern "state.sv" {
   ) -> (
     @[G, G+1] prev: #WIDTH,
   );
+}
+
+// A component that delays `in` by N cycles. Uses the Delay component under the
+// hood.
+comp Shift[#W, #N]<G: 1>(
+    @[G, G+1] in: #W
+) -> (
+    @[G+#N, G+#N+1] out: #W
+) {
+    bundle f[#N+1]: for<#i> @[G+#i, G+#i+1] #W;
+    f{0} = in;
+    for #i in 0..#N {
+        d := new Delay[#W]<G+#i>(f{#i});
+        f{#i+1} = d.out;
+    }
+    out = f{#N};
 }

--- a/primitives/state.sv
+++ b/primitives/state.sv
@@ -38,43 +38,6 @@ Register #(WIDTH) r (
 );
 endmodule
 
-// A shift register that connects N delay elements in series.
-module Shift #(
-    parameter WIDTH = 32,
-    parameter N = 1
-) (
-  input wire clk,
-  input wire reset,
-  input wire logic [WIDTH-1:0] in,
-  output logic [WIDTH-1:0] out
-);
-
-if (N == 0) begin:pass_through
-  wire unused = clk;
-  assign out = in;
-end:pass_through
-
-else begin:chained
-  logic [N:0][WIDTH-1:0] data_delayed;
-
-  assign data_delayed[0] = in;
-  assign out = data_delayed[N];
-
-  genvar i;
-  for(i=1; i<=N; i++) begin
-      Delay #(WIDTH)
-        ch_reg (
-          .clk(clk),
-          .reset(reset),
-          .in(data_delayed[i-1]),
-          .out(data_delayed[i])
-        );
-  end
-end:chained
-
-endmodule
-
-
 // Similar to a register but provides access to its previous value only.
 // Resetting behavior controlled using the SAFE parameter.
 module Prev #(

--- a/src/core/control.rs
+++ b/src/core/control.rs
@@ -17,8 +17,49 @@ impl Port {
         match &self.typ {
             PortType::ThisPort(n) => n.clone(),
             PortType::InvPort { name, .. } => name.clone(),
-            PortType::Bundle { name, idx } => format!("{name}[{idx}]").into(),
+            PortType::Bundle { name, idx } => format!("{name}{{{idx}}}").into(),
             PortType::Constant(n) => Id::from(format!("const<{}>", n)),
+        }
+    }
+
+    pub fn comp(comp: Id, name: Id) -> Self {
+        Port {
+            typ: PortType::InvPort { invoke: comp, name },
+            pos: GPosIdx::UNKNOWN,
+        }
+    }
+
+    pub fn this(p: Id) -> Self {
+        Port {
+            typ: PortType::ThisPort(p),
+            pos: GPosIdx::UNKNOWN,
+        }
+    }
+
+    pub fn constant(v: u64) -> Self {
+        Port {
+            typ: PortType::Constant(v),
+            pos: GPosIdx::UNKNOWN,
+        }
+    }
+
+    pub fn bundle(name: Id, idx: Expr) -> Self {
+        Port {
+            typ: PortType::Bundle { name, idx },
+            pos: GPosIdx::UNKNOWN,
+        }
+    }
+
+    pub fn resolve_exprs(self, bindings: &Binding<Expr>) -> Self {
+        match self.typ {
+            PortType::Bundle { name, idx } => Port {
+                typ: PortType::Bundle {
+                    name,
+                    idx: idx.resolve(bindings),
+                },
+                ..self
+            },
+            _ => self,
         }
     }
 }
@@ -58,36 +99,6 @@ pub enum PortType {
     Bundle { name: Id, idx: Expr },
 }
 
-impl Port {
-    pub fn comp(comp: Id, name: Id) -> Self {
-        Port {
-            typ: PortType::InvPort { invoke: comp, name },
-            pos: GPosIdx::UNKNOWN,
-        }
-    }
-
-    pub fn this(p: Id) -> Self {
-        Port {
-            typ: PortType::ThisPort(p),
-            pos: GPosIdx::UNKNOWN,
-        }
-    }
-
-    pub fn constant(v: u64) -> Self {
-        Port {
-            typ: PortType::Constant(v),
-            pos: GPosIdx::UNKNOWN,
-        }
-    }
-
-    pub fn bundle(name: Id, idx: Expr) -> Self {
-        Port {
-            typ: PortType::Bundle { name, idx },
-            pos: GPosIdx::UNKNOWN,
-        }
-    }
-}
-
 impl std::fmt::Display for PortType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -96,7 +107,7 @@ impl std::fmt::Display for PortType {
                 write!(f, "{}.{}", comp, name)
             }
             PortType::Constant(n) => write!(f, "{}", n),
-            PortType::Bundle { name, idx } => write!(f, "{name}[{idx}]"),
+            PortType::Bundle { name, idx } => write!(f, "{name}{{{idx}}}"),
         }
     }
 }
@@ -133,6 +144,12 @@ impl From<Instance> for Command {
 impl From<Invoke> for Command {
     fn from(v: Invoke) -> Self {
         Self::Invoke(v)
+    }
+}
+
+impl From<Bundle> for Command {
+    fn from(v: Bundle) -> Self {
+        Self::Bundle(v)
     }
 }
 
@@ -317,13 +334,10 @@ impl std::fmt::Display for Guard {
 pub struct Connect {
     /// Destination port
     pub dst: Port,
-
     /// Source port
     pub src: Port,
-
     /// Optional guard expression.
     pub guard: Option<Guard>,
-
     /// Source location of the invocation
     pos: GPosIdx,
 }
@@ -482,6 +496,14 @@ impl BundleType {
             bitwidth,
         }
     }
+
+    pub fn resolve_exprs(self, binding: &Binding<Expr>) -> Self {
+        Self {
+            idx: self.idx,
+            liveness: self.liveness.resolve_exprs(binding),
+            bitwidth: self.bitwidth.resolve(binding),
+        }
+    }
 }
 
 impl Display for BundleType {
@@ -499,9 +521,9 @@ pub struct Bundle {
     /// Name of the bundle
     pub name: Id,
     /// Length of the bundle
-    len: Expr,
+    pub len: Expr,
     /// Type of the bundle
-    typ: BundleType,
+    pub typ: BundleType,
 }
 
 impl Bundle {
@@ -518,6 +540,15 @@ impl Bundle {
             self.typ.liveness.resolve_exprs(&bind),
             self.typ.bitwidth.clone(),
         )
+    }
+
+    /// Resolve expressions in the Bundle
+    pub fn resolve_exprs(self, binding: &Binding<Expr>) -> Self {
+        Self {
+            name: self.name,
+            len: self.len.resolve(binding),
+            typ: self.typ.resolve_exprs(binding),
+        }
     }
 }
 

--- a/src/core/control.rs
+++ b/src/core/control.rs
@@ -468,7 +468,7 @@ impl Display for ForLoop {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "for #{} in {}..{} {{", self.idx, self.start, self.end)?;
         for cmd in &self.body {
-            write!(f, "{}", cmd)?;
+            writeln!(f, "{};", cmd)?;
         }
         write!(f, "}}")
     }
@@ -481,11 +481,11 @@ impl Display for ForLoop {
 /// ```
 pub struct BundleType {
     /// The name of the parameter for the bundle type
-    idx: Id,
+    pub idx: Id,
     /// Availability interval for the bundle
-    liveness: Range,
+    pub liveness: Range,
     /// Bitwidth of the bundle
-    bitwidth: Expr,
+    pub bitwidth: Expr,
 }
 
 impl BundleType {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn run(opts: &cmdline::Opts) -> Result<(), u64> {
     // Lowering
     let t = Instant::now();
     let Some(ns) =
-        passes::CompileInvokes::transform_unwrap(ns, states.max_states) else {
+        passes::Lower::transform_unwrap(ns, states.max_states) else {
             return Err(1);
         };
     log::info!("Lowering: {}ms", t.elapsed().as_millis());

--- a/src/passes/interval_checking/context.rs
+++ b/src/passes/interval_checking/context.rs
@@ -18,7 +18,7 @@ pub struct IntervalCheck {
     /// Diagnostics
     pub diag: diagnostics::Diagnostics,
     /// Variables used in the current set of constraints
-    vars: Vec<core::Id>,
+    pub(super) vars: Vec<core::Id>,
 }
 
 impl From<(FilSolver, diagnostics::Diagnostics)> for IntervalCheck {

--- a/src/passes/lower.rs
+++ b/src/passes/lower.rs
@@ -5,15 +5,19 @@ use crate::visitor;
 use itertools::Itertools;
 use std::collections::HashMap;
 
+/// Compiles high-level invokes into low-level invokes by instantiating FSMs and generating guards.
+/// Additionally removes all bundles and inlines their reads.
 #[derive(Default)]
-pub struct CompileInvokes {
+pub struct Lower {
     /// Mapping from events to FSMs
     fsms: HashMap<core::Id, core::Fsm>,
     /// Max state map
     max_states: HashMap<core::Id, HashMap<core::Id, u64>>,
+    /// Track writes to bundles
+    bundle_writes: HashMap<core::Id, Vec<Option<core::Port>>>,
 }
 
-impl CompileInvokes {
+impl Lower {
     fn find_fsm(&self, event: &core::Id) -> Option<&core::Fsm> {
         self.fsms.get(event)
     }
@@ -39,9 +43,23 @@ impl CompileInvokes {
             .unwrap();
         Some(guard)
     }
+
+    fn port(&self, port: core::Port) -> core::Port {
+        match port.typ {
+            core::PortType::Bundle { name, idx } => {
+                let idx = idx.concrete().unwrap() as usize;
+                let writes = self
+                    .bundle_writes
+                    .get(&name)
+                    .unwrap_or_else(|| panic!("No write to {name}{{{idx}}}"));
+                writes[idx].clone().unwrap()
+            }
+            _ => port.clone(),
+        }
+    }
 }
 
-impl visitor::Transform for CompileInvokes {
+impl visitor::Transform for Lower {
     /// Mapping from component -> event -> max state
     type Info = HashMap<Id, HashMap<Id, u64>>;
 
@@ -49,16 +67,52 @@ impl visitor::Transform for CompileInvokes {
         Self {
             fsms: HashMap::new(),
             max_states: max_states.clone(),
+            bundle_writes: HashMap::new(),
         }
     }
 
     fn clear_data(&mut self) {
         self.fsms.clear();
+        self.bundle_writes.clear();
     }
 
     /// Visit components with high-level invokes
     fn component_filter(&self, _: &CompBinding) -> bool {
         true
+    }
+
+    fn bundle(
+        &mut self,
+        bundle: core::Bundle,
+        _: &CompBinding,
+    ) -> FilamentResult<Vec<core::Command>> {
+        self.bundle_writes.insert(
+            bundle.name,
+            vec![None; bundle.len.concrete().unwrap() as usize],
+        );
+        Ok(vec![])
+    }
+
+    fn connect(
+        &mut self,
+        con: core::Connect,
+        _: &CompBinding,
+    ) -> FilamentResult<Vec<core::Command>> {
+        let src = self.port(con.src);
+        if let core::PortType::Bundle { name, idx } = con.dst.typ {
+            let idx = idx.concrete().unwrap() as usize;
+            debug_assert!(
+                self.bundle_writes[&name][idx].is_none(),
+                "multiple writes to {name}{{{idx}}}"
+            );
+            let writes = self.bundle_writes.get_mut(&name).unwrap();
+            writes[idx] = Some(src);
+            // Remove assignment to bundle port
+            Ok(vec![])
+        } else {
+            let con = core::Connect::new(con.dst, src, con.guard);
+            Ok(vec![con.into()])
+        }
     }
 
     // TODO(rachit): Document how the compilation works
@@ -110,8 +164,9 @@ impl visitor::Transform for CompileInvokes {
             }
 
             // Generate assignment for each port
-            for (port, formal) in ports.into_iter().zip(sig.inputs()) {
+            for (src, formal) in ports.into_iter().zip(sig.inputs()) {
                 let guard = self.range_to_guard(&formal.liveness);
+                let port = self.port(src);
                 let sp = port.copy_span();
                 let con = core::Connect::new(
                     core::Port::comp(bind.clone(), formal.name.clone()),

--- a/src/passes/lower.rs
+++ b/src/passes/lower.rs
@@ -48,11 +48,10 @@ impl Lower {
         match port.typ {
             core::PortType::Bundle { name, idx } => {
                 let idx = idx.concrete().unwrap() as usize;
-                let writes = self
-                    .bundle_writes
-                    .get(&name)
-                    .unwrap_or_else(|| panic!("No write to {name}{{{idx}}}"));
-                writes[idx].clone().unwrap()
+                let writes = self.bundle_writes.get(&name).unwrap();
+                writes[idx]
+                    .clone()
+                    .unwrap_or_else(|| panic!("No write to {name}{{{idx}}}"))
             }
             _ => port.clone(),
         }

--- a/src/passes/mod.rs
+++ b/src/passes/mod.rs
@@ -9,7 +9,7 @@ mod phantom_check;
 pub use bind_check::BindCheck;
 pub use dump_interface::DumpInterface;
 pub use interval_checking::IntervalCheck;
-pub use lower::CompileInvokes;
+pub use lower::Lower;
 pub use max_states::MaxStates;
 pub use monomorphize::Monomorphize;
 pub use phantom_check::PhantomCheck;

--- a/src/passes/monomorphize.rs
+++ b/src/passes/monomorphize.rs
@@ -431,9 +431,8 @@ impl Monomorphize {
                     ns.components.push(comp);
                 }
             } else {
-                // If we have a component with parameters but not bindings, it was probably unused.
+                // If we have a component with parameters but not bindings, it was not used.
                 if !comp.sig.params.is_empty() {
-                    log::warn!("skipping monomorphization for unused parameteric component `{}'", comp.sig.name);
                     continue;
                 }
                 let comp = Self::generate_comp(

--- a/src/visitor/visit.rs
+++ b/src/visitor/visit.rs
@@ -66,6 +66,15 @@ where
         Ok(sig)
     }
 
+    #[inline]
+    fn bundle(
+        &mut self,
+        bundle: core::Bundle,
+        _: &CompBinding,
+    ) -> FilamentResult<Vec<core::Command>> {
+        Ok(vec![bundle.into()])
+    }
+
     /// Perform computation before the component traversal
     #[inline]
     fn enter_component(
@@ -133,8 +142,8 @@ where
                     }
                     core::Command::Connect(con) => pass.connect(con, &ctx)?,
                     core::Command::Fsm(fsm) => pass.fsm(fsm, &ctx)?,
+                    core::Command::Bundle(bl) => pass.bundle(bl, &ctx)?,
                     core::Command::ForLoop(_) => todo!("Transforming loops"),
-                    core::Command::Bundle(_) => todo!("Transforming bundles"),
                 };
                 n_cmds.extend(cmds);
             }

--- a/tests/errors/bundle.expect
+++ b/tests/errors/bundle.expect
@@ -1,6 +1,14 @@
 ---CODE---
 1
 ---STDERR---
+error: Cannot prove constraint #N > 1
+   ┌─ tests/errors/bundle.fil:10:5
+   │
+10 │     f{1} = input;
+   │     ^^^^ cannot prove within-bounds bundle access: bundle of length #N with index 1
+   │
+   = assignment violates constraint: N=1
+
 error: Cannot prove constraint G+1 >= G+2
    ┌─ tests/errors/bundle.fil:10:12
    │
@@ -20,6 +28,14 @@ error: Cannot prove constraint G+#i >= G+#i+1
    │
    = assignment violates constraint: i=0
 
+error: Cannot prove constraint #N > #N+1
+   ┌─ tests/errors/bundle.fil:15:11
+   │
+15 │     out = f{#N+1};
+   │           ^^^^^^^ cannot prove within-bounds bundle access: bundle of length #N with index #N+1
+   │
+   = assignment violates constraint: N=1
+
 error: Cannot prove constraint G+#N >= G+#N+1
    ┌─ tests/errors/bundle.fil:15:11
    │
@@ -30,4 +46,4 @@ error: Cannot prove constraint G+#N >= G+#N+1
    │
    = assignment violates constraint: N=1
 
-Compilation failed with 3 errors.
+Compilation failed with 5 errors.

--- a/tests/errors/poly-mismatch.expect
+++ b/tests/errors/poly-mismatch.expect
@@ -2,9 +2,9 @@
 1
 ---STDERR---
 error: Cannot prove constraint G+#W >= G+#N
-   ┌─ tests/errors/poly-mismatch.fil:17:28
+   ┌─ tests/errors/poly-mismatch.fil:12:28
    │
-17 │     a := new Add[#W]<G+#W>(s.out, acc);
+12 │     a := new Add[#W]<G+#W>(s.out, acc);
    │                            ^^^^^ source is available for @[G+#N, G+#N+1]
    │
    ┌─ ./primitives/core.fil:11:13
@@ -15,9 +15,9 @@ error: Cannot prove constraint G+#W >= G+#N
    = assignment violates constraint: W=1, N=2
 
 error: Cannot prove constraint G+#N+1 >= G+#W+1
-   ┌─ tests/errors/poly-mismatch.fil:17:28
+   ┌─ tests/errors/poly-mismatch.fil:12:28
    │
-17 │     a := new Add[#W]<G+#W>(s.out, acc);
+12 │     a := new Add[#W]<G+#W>(s.out, acc);
    │                            ^^^^^ source is available for @[G+#N, G+#N+1]
    │
    ┌─ ./primitives/core.fil:11:13
@@ -28,9 +28,9 @@ error: Cannot prove constraint G+#N+1 >= G+#W+1
    = assignment violates constraint: N=0, W=1
 
 error: Cannot prove constraint G+#W >= G+#N
-   ┌─ tests/errors/poly-mismatch.fil:17:35
+   ┌─ tests/errors/poly-mismatch.fil:12:35
    │
-17 │     a := new Add[#W]<G+#W>(s.out, acc);
+12 │     a := new Add[#W]<G+#W>(s.out, acc);
    │                                   ^^^ source is available for @[G+#N, G+#N+1]
    │
    ┌─ ./primitives/core.fil:12:13
@@ -41,9 +41,9 @@ error: Cannot prove constraint G+#W >= G+#N
    = assignment violates constraint: W=1, N=2
 
 error: Cannot prove constraint G+#N+1 >= G+#W+1
-   ┌─ tests/errors/poly-mismatch.fil:17:35
+   ┌─ tests/errors/poly-mismatch.fil:12:35
    │
-17 │     a := new Add[#W]<G+#W>(s.out, acc);
+12 │     a := new Add[#W]<G+#W>(s.out, acc);
    │                                   ^^^ source is available for @[G+#N, G+#N+1]
    │
    ┌─ ./primitives/core.fil:12:13
@@ -54,9 +54,9 @@ error: Cannot prove constraint G+#N+1 >= G+#W+1
    = assignment violates constraint: N=0, W=1
 
 error: Cannot prove constraint G+#W+1 >= G+#N+1
-   ┌─ tests/errors/poly-mismatch.fil:18:11
+   ┌─ tests/errors/poly-mismatch.fil:13:11
    │
-18 │     out = a.out;
+13 │     out = a.out;
    │     ---   ^^^^^ source is available for @[G+#W, G+#W+1]
    │     │      
    │     destination's requirement @[G+#N, G+#N+1]
@@ -64,9 +64,9 @@ error: Cannot prove constraint G+#W+1 >= G+#N+1
    = assignment violates constraint: W=1, N=2
 
 error: Cannot prove constraint G+#N >= G+#W
-   ┌─ tests/errors/poly-mismatch.fil:18:11
+   ┌─ tests/errors/poly-mismatch.fil:13:11
    │
-18 │     out = a.out;
+13 │     out = a.out;
    │     ---   ^^^^^ source is available for @[G+#W, G+#W+1]
    │     │      
    │     destination's requirement @[G+#N, G+#N+1]
@@ -74,9 +74,9 @@ error: Cannot prove constraint G+#N >= G+#W
    = assignment violates constraint: N=0, W=1
 
 error: Cannot prove constraint G+3 >= G+5
-   ┌─ tests/errors/poly-mismatch.fil:25:11
+   ┌─ tests/errors/poly-mismatch.fil:20:11
    │
-25 │     out = s.out;
+20 │     out = s.out;
    │     ---   ^^^^^ source is available for @[G+2, G+3]
    │     │      
    │     destination's requirement @[G+4, G+5]

--- a/tests/errors/poly-mismatch.fil
+++ b/tests/errors/poly-mismatch.fil
@@ -1,10 +1,5 @@
 import "primitives/core.fil";
 
-/// This file doesn't acutally contain a shift register
-extern "../../primitives/state.fil" {
-    comp Shift[#W, #N]<G: 1>(@[G, G+1] in: #W) -> (@[G+#N, G+#N+1] out: #W);
-}
-
 comp Mac[#W, #N]<G: 1>(
     @[G, G+1] left: #W,
     @[G, G+1] right: #W,

--- a/tools/vscode/syntaxes/filament.tmLanguage.json
+++ b/tools/vscode/syntaxes/filament.tmLanguage.json
@@ -60,7 +60,7 @@
 				},
 				{
 					"name": "keyword.control.filament",
-					"match": "\\b(where|for|in)\\b"
+					"match": "\\b(where|for)\\b"
 				}
 			]
 		},
@@ -72,6 +72,17 @@
 				},
 				{
 					"match": "\\b(fsm)\\b\\s+\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+					"captures": {
+						"1": {
+							"name": "keyword.control.filament"
+						},
+						"2": {
+							"name": "support.class"
+						}
+					}
+				},
+				{
+					"match": "\\b(bundle)\\b\\s+\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
 					"captures": {
 						"1": {
 							"name": "keyword.control.filament"


### PR DESCRIPTION
Completes the implementation of the `bundle` construct which allow exchanging information across loop boundaries. We need to implement a separate linearity check sometime in the future to ensure all locations of bundle are written to (and more generally, all outputs to a component have an assignment). 

This also allows us to implement the shift register primitive `Shift` directly inside Filament and write down parameterized implementations of the various dividers.