### PR TITLE
Allow generic binary expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ derivative = "2.2"
 smallvec = "1"
 topological-sort = "0.2"
 atty = "0.2"
+lazy_static = "1.4.0"
 
 [dependencies.calyx]
 path = "../calyx/calyx"

--- a/evaluation/iterative-divider/base.fil
+++ b/evaluation/iterative-divider/base.fil
@@ -1,6 +1,5 @@
 import "primitives/core.fil";
 
-// XXX: We need #L because we can't say #W-1
 comp Next[#W]<G: 1>(
   @[G, G+1] acc: #W+1,
   @[G, G+1] right: #W,

--- a/evaluation/iterative-divider/base.fil
+++ b/evaluation/iterative-divider/base.fil
@@ -1,0 +1,63 @@
+import "primitives/core.fil";
+
+// XXX: We need #L because we can't say #W-1
+comp Next[#W]<G: 1>(
+  @[G, G+1] acc: #W+1,
+  @[G, G+1] right: #W,
+  @[G, G+1] quotient: #W,
+) -> (
+  @[G, G+1] acc_next: #W+1,
+  @[G, G+1] quotient_next: #W,
+) where #W > 0 {
+
+  /*
+  assign right_ext = {1'b0, right};
+  assign check = acc >= right_ext;
+
+  // True branch
+  assign sub = acc - right;
+  assign c = check ? {sub[7:0], quotient, 1'b1} : ({acc, quotient} << 1);
+
+  assign quotient_next = c[7:0];
+  assign acc_next = c[16:8];
+  */
+
+  right_ext := new ZeroExtend[#W, #W+1]<G>(right);
+  check := new Gte[#W+1]<G>(acc, right_ext.out);
+
+  // True branch
+  sub := new Sub[#W+1]<G>(acc, right_ext.out);
+  sub_slice := new Slice[#W+1, #W-1, 0, #W]<G>(sub.out);
+  one_1 := new Const[1, 1]<G>();
+  true_con_0 := new Concat[#W, 1, #W+1]<G>(quotient, one_1.out);
+  true_con := new Concat[#W, #W+1, 2*#W+1]<G>(sub_slice.out, true_con_0.out);
+
+  // False branch
+  fal_con := new Concat[#W+1, #W, 2*#W+1]<G>(acc, quotient);
+  one_WW1 := new Const[2*#W+1, 1]<G>();
+  fal_sh := new ShiftLeft[2*#W+1]<G>(fal_con.out, one_WW1.out);
+
+  c := new Mux[2*#W+1]<G>(check.out, true_con.out, fal_sh.out);
+
+  acc_slice := new Slice[2*#W+1, 2*#W, #W, #W+1]<G>(c.out);
+  q_slice := new Slice[2*#W+1, #W, 0, #W]<G>(c.out);
+
+  quotient_next = q_slice.out;
+  acc_next = acc_slice.out;
+}
+
+comp Init[#W]<G: 1>(
+  @[G, G+1] left: #W,
+) -> (
+  @[G, G+1] acc: #W+1,
+  @[G, G+1] quotient: #W,
+) where #W > 0 {
+  zero_one := new Const[1, 0]<G>();
+  c := new Concat[#W, 1, #W+1]<G>(left, zero_one.out);
+  c_ext := new ZeroExtend[#W+1, 2*#W+1]<G>(c.out);
+  acc_slice := new Slice[2*#W+1, 2*#W, #W, #W+1]<G>(c_ext.out);
+  q_slice := new Slice[2*#W+1, #W, 0, #W]<G>(c_ext.out);
+
+  acc = acc_slice.out;
+  quotient = q_slice.out;
+}

--- a/evaluation/iterative-divider/fields
+++ b/evaluation/iterative-divider/fields
@@ -1,1 +1,1 @@
-comb_noshare verilog share pipe
+comb_noshare verilog share pipe tradeoff

--- a/evaluation/iterative-divider/harness.fil
+++ b/evaluation/iterative-divider/harness.fil
@@ -43,10 +43,13 @@ comp main<G: 11>(
   @[G+9, G+10] verilog: 8,
   @[G+8, G+9] share: 8,
   @[G+8, G+9] pipe: 8,
+  @[G+8, G+9] tradeoff: 8,
 ) {
   d := new DiffTest[8, 7]<G>(left, right);
+  td := new TradeoffDiv[8, 4, 2, 7]<G>(left, right);
   verilog = d.verilog;
   comb_noshare = d.comb_noshare;
   share = d.share;
   pipe = d.pipe;
+  tradeoff = td.out;
 }

--- a/evaluation/iterative-divider/harness.fil
+++ b/evaluation/iterative-divider/harness.fil
@@ -14,7 +14,7 @@ extern "iter-div.sv" {
   ) where #W > 0;
 }
 
-comp DiffTest[#W, #L]<G: #W+1>(
+comp DiffTest[#W]<G: #W+1>(
   @interface[G] go: 1,
   @[G, G+1] left: #W,
   @[G, G+#W+1] right: #W,
@@ -23,11 +23,11 @@ comp DiffTest[#W, #L]<G: #W+1>(
   @[G+#W+1, G+#W+2] verilog: #W,
   @[G+#W, G+#W+1] share: #W,
   @[G+#W, G+#W+1] pipe: #W,
-) where #W > 0, #W = #L + 1 {
+) where #W > 0 {
   d := new IterDiv[#W]<G>(left, right);
-  id := new CombNoShareIterDiv[#W, #L]<G>(left, right);
-  s := new ShareIterDiv[#W, #L]<G>(left, right);
-  pipe := new PipeIterDiv[#W, #L]<G>(left, right);
+  id := new CombNoShareIterDiv[#W]<G>(left, right);
+  s := new ShareIterDiv[#W]<G>(left, right);
+  pipe := new PipeIterDiv[#W]<G>(left, right);
   verilog = d.out_quotient;
   comb_noshare = id.quotient;
   share = s.quotient;
@@ -45,8 +45,8 @@ comp main<G: 11>(
   @[G+8, G+9] pipe: 8,
   @[G+8, G+9] tradeoff: 8,
 ) {
-  d := new DiffTest[8, 7]<G>(left, right);
-  td := new TradeoffDiv[8, 4, 2, 7]<G>(left, right);
+  d := new DiffTest[8]<G>(left, right);
+  td := new TradeoffDiv[8, 4, 2]<G>(left, right);
   verilog = d.verilog;
   comb_noshare = d.comb_noshare;
   share = d.share;

--- a/evaluation/iterative-divider/iter-div.fil
+++ b/evaluation/iterative-divider/iter-div.fil
@@ -43,7 +43,7 @@ comp TradeoffDiv[#W, #I, #K]<G: #K>(
 {
 
     /// Bundles that track the "outer" signals which connect each reused instance in the circuit.
-    bundle o_acc[#I+1]: for<#a> @[G+#a*#K, G+#a*#K+1] #W;
+    bundle o_acc[#I+1]: for<#a> @[G+#a*#K, G+#a*#K+1] #W+1;
     bundle o_qn [#I+1]: for<#a> @[G+#a*#K, G+#a*#K+1] #W;
     bundle o_r  [#I+1]: for<#a> @[G+#a*#K, G+#a*#K+1] #W;
 
@@ -74,10 +74,10 @@ comp TradeoffDiv[#W, #I, #K]<G: #K>(
         for #j in 0..#K {
             s := N<G+(#K*#i)+#j>(acc{#j}, r{#j}, qn{#j});
             acc_reg := Acc<G+(#K*#i)+#j>(s.acc_next);
-            acc{#j+1} = acc_reg.out;
             qn_reg := QN<G+(#K*#i)+#j>(s.quotient_next);
-            qn{#j+1} = qn_reg.out;
             r_reg := R<G+(#K*#i)+#j>(r{#j});
+            acc{#j+1} = acc_reg.out;
+            qn{#j+1} = qn_reg.out;
             r{#j+1} = r_reg.out;
         }
 

--- a/evaluation/iterative-divider/iter-div.fil
+++ b/evaluation/iterative-divider/iter-div.fil
@@ -93,32 +93,8 @@ comp ShareIterDiv[#W, #L]<G: #W>(
 ) -> (
   @[G+#W, G+#W+1] quotient: #W
 ) where #W > 0, #W = #L + 1 {
-  bundle acc[#W+1]: for<#i> @[G+#i, G+#i+1] #W+1;
-  bundle qn[#W+1]: for<#i> @[G+#i, G+#i+1] #W;
-  bundle r[#W+1]: for<#i> @[G+#i, G+#i+1] #W;
-
-  i := new Init[#W]<G>(left);
-  acc{0} = i.acc;
-  qn{0} = i.quotient;
-  r{0} = right;
-
-  N := new Next[#W, #L];
-  Acc := new Delay[#W+1];
-  QN := new Delay[#W];
-  R := new Delay[#W];
-
-  for #i in 0..#W {
-    s := N<G+#i>(acc{#i}, r{#i}, qn{#i});
-    acc_reg := Acc<G+#i>(s.acc_next);
-    acc{#i+1} = acc_reg.out;
-    qn_reg := QN<G+#i>(s.quotient_next);
-    qn{#i+1} = qn_reg.out;
-    r_reg := R<G+#i>(r{#i});
-    r{#i+1} = r_reg.out;
-  }
-
-  // Iterate 7 more times
-  quotient = qn{#W};
+  td := new TradeoffDiv[#W, 1, #W, #L]<G>(left, right);
+  quotient = td.out;
 }
 
 comp PipeIterDiv[#W, #L]<G: 1>(
@@ -127,28 +103,66 @@ comp PipeIterDiv[#W, #L]<G: 1>(
   @[G, G+1] right: #W,
 ) -> (
   @[G+#W, G+#W+1] quotient: #W
-) where #W > 0, #W = #L + 1 {
-  bundle acc[#W+1]: for<#i> @[G+#i, G+#i+1] #W+1;
-  bundle qn[#W+1]: for<#i> @[G+#i, G+#i+1] #W;
-  bundle r[#W+1]: for<#i> @[G+#i, G+#i+1] #W;
+) where #W > 0, #L = #W - 1 {
+  td := new TradeoffDiv[#W, #W, 1, #L]<G>(left, right);
+  quotient = td.out;
+}
 
-  i := new Init[#W]<G>(left);
-  acc{0} = i.acc;
-  qn{0} = i.quotient;
-  r{0} = right;
 
-  for #i in 0..#W {
-    s := new Next[#W, #L]<G+#i>(acc{#i}, r{#i}, qn{#i});
-    acc_reg := new Delay[#W+1]<G+#i>(s.acc_next);
-    acc{#i+1} = acc_reg.out;
-    qn_reg := new Delay[#W]<G+#i>(s.quotient_next);
-    qn{#i+1} = qn_reg.out;
-    r_reg := new Delay[#W]<G+#i>(r{#i});
-    r{#i+1} = r_reg.out;
-  }
+// An iterative divider that instantiates `I` circuits and reuses them for `K`
+// cycles.
+comp TradeoffDiv[#W, #I, #K, #L]<G: #K>(
+  @interface[G] go: 1,
+  @[G, G+1] left: #W,
+  @[G, G+1] right: #W,
+) -> (
+    @[G+#W, G+#W+1] out: #W,
+) where #I > 0, #K > 0, #W = #I * #K, #L = #W - 1 {
 
-  // This unecessarily registers the last value of the quotient increasing the
-  // latency by 1 increasing the latency by 1.
+    /// Bundles that track the "outer" signals which connect each reused instance in the circuit.
+    bundle o_acc[#I+1]: for<#a> @[G+#a*#K, G+#a*#K+1] #W;
+    bundle o_qn [#I+1]: for<#a> @[G+#a*#K, G+#a*#K+1] #W;
+    bundle o_r  [#I+1]: for<#a> @[G+#a*#K, G+#a*#K+1] #W;
 
-  quotient = qn{#W};
+    i := new Init[#W]<G>(left);
+    o_acc{0} = i.acc;
+    o_qn{0} = i.quotient;
+    o_r{0} = right;
+
+    for #i in 0..#I {
+
+        // Instantiate the I'th circuit
+        N := new Next[#W, #L];
+        Acc := new Delay[#W+1];
+        QN := new Delay[#W];
+        R := new Delay[#W];
+
+        // Bundles to forward data
+        // Each bundle starts at time #K*#i which represents the previous
+        // computations that have already occurred.
+        bundle acc[#K+1]: for<#a> @[G+(#K*#i)+#a, G+(#K*#i)+#a+1] #W+1;
+        bundle qn [#K+1]: for<#a> @[G+(#K*#i)+#a, G+(#K*#i)+#a+1] #W;
+        bundle r  [#K+1]: for<#a> @[G+(#K*#i)+#a, G+(#K*#i)+#a+1] #W;
+
+        acc{0} = o_acc{#i};
+        qn{0} = o_qn{#i};
+        r{0} = o_r{#i};
+
+        for #j in 0..#K {
+            s := N<G+(#K*#i)+#j>(acc{#j}, r{#j}, qn{#j});
+            acc_reg := Acc<G+(#K*#i)+#j>(s.acc_next);
+            acc{#j+1} = acc_reg.out;
+            qn_reg := QN<G+(#K*#i)+#j>(s.quotient_next);
+            qn{#j+1} = qn_reg.out;
+            r_reg := R<G+(#K*#i)+#j>(r{#j});
+            r{#j+1} = r_reg.out;
+        }
+
+        o_acc{#i+1} = acc{#K};
+        o_qn{#i+1} = qn{#K};
+        o_r{#i+1} = r{#K};
+    }
+
+    out = o_qn{#I};
+
 }

--- a/evaluation/iterative-divider/iter-div.fil
+++ b/evaluation/iterative-divider/iter-div.fil
@@ -1,74 +1,13 @@
 import "primitives/core.fil";
+import "base.fil";
 
-// XXX: We need #L because we can't say #W-1
-comp Next[#W, #L]<G: 1>(
-  @[G, G+1] acc: #W+1,
-  @[G, G+1] right: #W,
-  @[G, G+1] quotient: #W,
-) -> (
-  @[G, G+1] acc_next: #W+1,
-  @[G, G+1] quotient_next: #W,
-) where #W > 0, #W = #L + 1 {
-
-  /*
-  assign right_ext = {1'b0, right};
-  assign check = acc >= right_ext;
-
-  // True branch
-  assign sub = acc - right;
-  assign c = check ? {sub[7:0], quotient, 1'b1} : ({acc, quotient} << 1);
-
-  assign quotient_next = c[7:0];
-  assign acc_next = c[16:8];
-  */
-
-  right_ext := new ZeroExtend[#W, #W+1]<G>(right);
-  check := new Gte[#W+1]<G>(acc, right_ext.out);
-
-  // True branch
-  sub := new Sub[#W+1]<G>(acc, right_ext.out);
-  sub_slice := new Slice[#W+1, #L, 0, #W]<G>(sub.out);
-  one_1 := new Const[1, 1]<G>();
-  true_con_0 := new Concat[#W, 1, #W+1]<G>(quotient, one_1.out);
-  true_con := new Concat[#W, #W+1, #W+#W+1]<G>(sub_slice.out, true_con_0.out);
-
-  // False branch
-  fal_con := new Concat[#W+1, #W, #W+#W+1]<G>(acc, quotient);
-  one_WW1 := new Const[#W+#W+1, 1]<G>();
-  fal_sh := new ShiftLeft[#W+#W+1]<G>(fal_con.out, one_WW1.out);
-
-  c := new Mux[#W+#W+1]<G>(check.out, true_con.out, fal_sh.out);
-
-  acc_slice := new Slice[#W+#W+1, #W+#W, #W, #W+1]<G>(c.out);
-  q_slice := new Slice[#W+#W+1, #W, 0, #W]<G>(c.out);
-
-  quotient_next = q_slice.out;
-  acc_next = acc_slice.out;
-}
-
-comp Init[#W]<G: 1>(
-  @[G, G+1] left: #W,
-) -> (
-  @[G, G+1] acc: #W+1,
-  @[G, G+1] quotient: #W,
-) where #W > 0 {
-  zero_one := new Const[1, 0]<G>();
-  c := new Concat[#W, 1, #W+1]<G>(left, zero_one.out);
-  c_ext := new ZeroExtend[#W+1, #W+#W+1]<G>(c.out);
-  acc_slice := new Slice[#W+#W+1, #W+#W, #W, #W+1]<G>(c_ext.out);
-  q_slice := new Slice[#W+#W+1, #W, 0, #W]<G>(c_ext.out);
-
-  acc = acc_slice.out;
-  quotient = q_slice.out;
-}
-
-comp CombNoShareIterDiv[#W, #L]<G: 1>(
+comp CombNoShareIterDiv[#W]<G: 1>(
   @interface[G] go: 1,
   @[G, G+1] left: #W,
   @[G, G+1] right: #W,
 ) -> (
   @[G, G+1] quotient: #W
-) where #W > 0, #W = #L + 1 {
+) where #W > 0 {
   bundle acc[#W+1]: for<#i> @[G, G+1] #W+1;
   bundle quotient_next[#W+1]: for<#i> @[G, G+1] #W;
 
@@ -78,7 +17,7 @@ comp CombNoShareIterDiv[#W, #L]<G: 1>(
   quotient_next{0} = init.quotient;
 
   for #i in 0..#W {
-    s := new Next[#W, #L]<G>(acc{#i}, right, quotient_next{#i});
+    s := new Next[#W]<G>(acc{#i}, right, quotient_next{#i});
     acc{#i+1} = s.acc_next;
     quotient_next{#i+1} = s.quotient_next;
   }
@@ -86,38 +25,22 @@ comp CombNoShareIterDiv[#W, #L]<G: 1>(
   quotient = quotient_next{#W};
 }
 
-comp ShareIterDiv[#W, #L]<G: #W>(
+/// An iterative divider that instantiates `I` circuits and reuses them for `K`
+/// cycles.
+/// At a high-level, we use two sets of bundles
+///  1. Bundles that track the "outer" signals which forward signals between the reused instances.
+///  2. Bundles that track the "inner" signals which "loop back" the signals into the reused instances.
+comp TradeoffDiv[#W, #I, #K]<G: #K>(
   @interface[G] go: 1,
   @[G, G+1] left: #W,
   @[G, G+1] right: #W,
 ) -> (
-  @[G+#W, G+#W+1] quotient: #W
-) where #W > 0, #W = #L + 1 {
-  td := new TradeoffDiv[#W, 1, #W, #L]<G>(left, right);
-  quotient = td.out;
-}
-
-comp PipeIterDiv[#W, #L]<G: 1>(
-  @interface[G] go: 1,
-  @[G, G+1] left: #W,
-  @[G, G+1] right: #W,
-) -> (
-  @[G+#W, G+#W+1] quotient: #W
-) where #W > 0, #L = #W - 1 {
-  td := new TradeoffDiv[#W, #W, 1, #L]<G>(left, right);
-  quotient = td.out;
-}
-
-
-// An iterative divider that instantiates `I` circuits and reuses them for `K`
-// cycles.
-comp TradeoffDiv[#W, #I, #K, #L]<G: #K>(
-  @interface[G] go: 1,
-  @[G, G+1] left: #W,
-  @[G, G+1] right: #W,
-) -> (
-    @[G+#W, G+#W+1] out: #W,
-) where #I > 0, #K > 0, #W = #I * #K, #L = #W - 1 {
+  @[G+#W, G+#W+1] out: #W,
+) where
+  #I > 0,
+  #K > 0,
+  #W = #I * #K
+{
 
     /// Bundles that track the "outer" signals which connect each reused instance in the circuit.
     bundle o_acc[#I+1]: for<#a> @[G+#a*#K, G+#a*#K+1] #W;
@@ -130,9 +53,8 @@ comp TradeoffDiv[#W, #I, #K, #L]<G: #K>(
     o_r{0} = right;
 
     for #i in 0..#I {
-
         // Instantiate the I'th circuit
-        N := new Next[#W, #L];
+        N := new Next[#W];
         Acc := new Delay[#W+1];
         QN := new Delay[#W];
         R := new Delay[#W];
@@ -148,6 +70,7 @@ comp TradeoffDiv[#W, #I, #K, #L]<G: #K>(
         qn{0} = o_qn{#i};
         r{0} = o_r{#i};
 
+        // Loop back the computation into the same circuit for K cycles.
         for #j in 0..#K {
             s := N<G+(#K*#i)+#j>(acc{#j}, r{#j}, qn{#j});
             acc_reg := Acc<G+(#K*#i)+#j>(s.acc_next);
@@ -158,11 +81,36 @@ comp TradeoffDiv[#W, #I, #K, #L]<G: #K>(
             r{#j+1} = r_reg.out;
         }
 
+        // Forward signals from the final reuse to the next circuit.
         o_acc{#i+1} = acc{#K};
         o_qn{#i+1} = qn{#K};
         o_r{#i+1} = r{#K};
     }
 
     out = o_qn{#I};
-
 }
+
+/// An iterative divider that uses exactly one `Next` circuit and shares it over W cycles.
+comp ShareIterDiv[#W]<G: #W>(
+  @interface[G] go: 1,
+  @[G, G+1] left: #W,
+  @[G, G+1] right: #W,
+) -> (
+  @[G+#W, G+#W+1] quotient: #W
+) where #W > 0 {
+  td := new TradeoffDiv[#W, 1, #W]<G>(left, right);
+  quotient = td.out;
+}
+
+/// An iterative divider that uses W `Next` circuits and does not share them.
+comp PipeIterDiv[#W]<G: 1>(
+  @interface[G] go: 1,
+  @[G, G+1] left: #W,
+  @[G, G+1] right: #W,
+) -> (
+  @[G+#W, G+#W+1] quotient: #W
+) where #W > 0 {
+  td := new TradeoffDiv[#W, #W, 1]<G>(left, right);
+  quotient = td.out;
+}
+

--- a/src/backend/compile.rs
+++ b/src/backend/compile.rs
@@ -434,10 +434,13 @@ fn prim_as_port_defs(sig: &core::Signature) -> Vec<ir::PortDef<ir::Width>> {
     let port_transform =
         |pd: &core::PortDef, dir: ir::Direction| -> ir::PortDef<ir::Width> {
             let w = &pd.bitwidth;
-            let width = match w.abs.len() {
-                0 => ir::Width::Const { value: w.concrete },
+            let abs = w.exprs();
+            let width = match abs.len() {
+                0 => ir::Width::Const {
+                    value: w.concrete().unwrap(),
+                },
                 1 => ir::Width::Param {
-                    value: w.abs[0].as_ref().into(),
+                    value: abs[0].as_ref().into(),
                 },
                 _ => panic!("cannot complex width expr: {w}"),
             };

--- a/src/backend/compile.rs
+++ b/src/backend/compile.rs
@@ -1,5 +1,5 @@
 use super::Fsm;
-use crate::{cmdline::Opts, core, errors::FilamentResult, utils::PostOrder};
+use crate::{cmdline::Opts, core, errors::FilamentResult, utils::Traversal};
 use calyx::{
     errors::CalyxResult,
     frontend,
@@ -522,7 +522,7 @@ pub fn compile(ns: core::Namespace, opts: &Opts) {
 
     let mut bindings = Binding::default();
 
-    let mut po = PostOrder::from(ns);
+    let mut po = Traversal::from(ns);
 
     po.apply_pre_order(|comp| {
         let comp = compile_component(comp, &mut bindings, &calyx_ctx.lib)

--- a/src/backend/compile.rs
+++ b/src/backend/compile.rs
@@ -341,13 +341,14 @@ fn compile_component(
     sigs: &mut Binding,
     lib: &ir::LibrarySignatures,
 ) -> FilamentResult<ir::Component> {
-    let port_transform =
-        |pd: &core::PortDef, dir: ir::Direction| -> ir::PortDef<u64> {
-            let mut pd: ir::PortDef<u64> =
-                (pd.name.as_ref(), pd.bitwidth.concrete().unwrap(), dir).into();
-            pd.attributes.insert("data", 1);
-            pd
-        };
+    let port_transform = |pd: &core::PortDef,
+                          dir: ir::Direction|
+     -> ir::PortDef<u64> {
+        let mut pd: ir::PortDef<u64> =
+            (pd.name.as_ref(), (&pd.bitwidth).try_into().unwrap(), dir).into();
+        pd.attributes.insert("data", 1);
+        pd
+    };
     let concrete_transform =
         |name: &core::Id, width: u64| -> ir::PortDef<u64> {
             (name.as_ref(), width, ir::Direction::Input).into()
@@ -402,7 +403,7 @@ fn compile_component(
                 } else {
                     let conc_bind = bindings
                         .into_iter()
-                        .map(|v| v.concrete().unwrap())
+                        .map(|v| (&v).try_into().unwrap())
                         .collect_vec();
                     ctx.builder.add_primitive(
                         name.as_ref(),
@@ -437,7 +438,7 @@ fn prim_as_port_defs(sig: &core::Signature) -> Vec<ir::PortDef<ir::Width>> {
             let abs = w.exprs();
             let width = match abs.len() {
                 0 => ir::Width::Const {
-                    value: w.concrete().unwrap(),
+                    value: w.try_into().unwrap(),
                 },
                 1 => ir::Width::Param {
                     value: abs[0].as_ref().into(),

--- a/src/backend/compile.rs
+++ b/src/backend/compile.rs
@@ -435,7 +435,7 @@ fn prim_as_port_defs(sig: &core::Signature) -> Vec<ir::PortDef<ir::Width>> {
     let port_transform =
         |pd: &core::PortDef, dir: ir::Direction| -> ir::PortDef<ir::Width> {
             let w = &pd.bitwidth;
-            let abs = w.exprs();
+            let abs = w.exprs().collect_vec();
             let width = match abs.len() {
                 0 => ir::Width::Const {
                     value: w.try_into().unwrap(),

--- a/src/binding/instance.rs
+++ b/src/binding/instance.rs
@@ -26,7 +26,7 @@ impl InstIdx {
         ctx: &CompBinding,
     ) -> core::Signature {
         let inst = &ctx[*self];
-        ctx.prog[inst.sig].resolve_offset(&inst.params)
+        ctx.prog[inst.sig].clone().resolve_exprs(&inst.params)
     }
 }
 

--- a/src/binding/instance.rs
+++ b/src/binding/instance.rs
@@ -1,8 +1,8 @@
 use super::{CompBinding, InvIdx, SigIdx};
-use crate::{core, utils};
+use crate::{core, idx};
 use crate::{errors::WithPos, utils::GPosIdx};
 
-pub type InstIdx = utils::Idx<BoundInstance>;
+pub type InstIdx = idx!(BoundInstance);
 
 impl InstIdx {
     /// Get the position of the instance

--- a/src/binding/invoke.rs
+++ b/src/binding/invoke.rs
@@ -22,7 +22,7 @@ impl InvIdx {
 
         inv.events
             .iter()
-            .map(|e| e.resolve_expr(&param_b))
+            .map(|e| e.clone().resolve_expr(&param_b))
             .collect()
     }
 
@@ -120,7 +120,7 @@ impl InvIdx {
         let sig = &ctx.prog[sig_idx];
         sig.constraints
             .iter()
-            .map(|c| c.resolve_event(event_b).resolve_expr(param_b))
+            .map(|c| c.clone().resolve_event(event_b).resolve_expr(param_b))
             .chain(
                 sig.well_formed(diag)
                     .into_iter()

--- a/src/binding/invoke.rs
+++ b/src/binding/invoke.rs
@@ -1,12 +1,12 @@
 use super::{CompBinding, InstIdx, SigIdx};
 use crate::core::{self, Id, Time, TimeSub};
-use crate::diagnostics;
 use crate::errors::WithPos;
 use crate::utils::{self, GPosIdx};
+use crate::{diagnostics, idx};
 use itertools::Itertools;
 
 /// Index to a bound invocation
-pub type InvIdx = utils::Idx<BoundInvoke>;
+pub type InvIdx = idx!(BoundInvoke);
 
 impl InvIdx {
     /// Get the position of the invocation

--- a/src/binding/prog.rs
+++ b/src/binding/prog.rs
@@ -2,13 +2,13 @@ use crate::{
     core::{self, Id},
     diagnostics,
     errors::{Error, WithPos},
-    utils,
+    idx,
 };
 use std::collections::HashMap;
 
 use super::BoundComponent;
 
-pub type SigIdx = utils::Idx<core::Signature>;
+pub type SigIdx = idx!(core::Signature);
 
 /// Signatures bound in a program.
 /// Also acts a dispatcher for methods on [core::Signature] since external and

--- a/src/core/constraint.rs
+++ b/src/core/constraint.rs
@@ -167,7 +167,7 @@ where
 }
 
 /// A ordering constraint over time expressions or time ranges.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Hash)]
 pub enum Constraint {
     Base {
         base: OrderConstraint<Time>,

--- a/src/core/constraint.rs
+++ b/src/core/constraint.rs
@@ -84,37 +84,37 @@ where
 }
 
 impl OrderConstraint<Time> {
-    fn resolve_event(&self, bindings: &Binding<Time>) -> Self {
+    fn resolve_event(self, bindings: &Binding<Time>) -> Self {
         OrderConstraint {
             left: self.left.resolve_event(bindings),
             right: self.right.resolve_event(bindings),
-            ..self.clone()
+            ..self
         }
     }
 
-    fn resolve_expr(&self, bindings: &Binding<Expr>) -> Self {
+    fn resolve_expr(self, bindings: &Binding<Expr>) -> Self {
         OrderConstraint {
             left: self.left.resolve_expr(bindings),
             right: self.right.resolve_expr(bindings),
-            ..self.clone()
+            ..self
         }
     }
 }
 
 impl OrderConstraint<TimeSub> {
-    fn resolve_event(&self, bindings: &Binding<Time>) -> Self {
+    fn resolve_event(self, bindings: &Binding<Time>) -> Self {
         OrderConstraint {
             left: self.left.resolve_event(bindings),
             right: self.right.resolve_event(bindings),
-            ..self.clone()
+            ..self
         }
     }
 
-    fn resolve_expr(&self, bindings: &Binding<Expr>) -> Self {
+    fn resolve_expr(self, bindings: &Binding<Expr>) -> Self {
         OrderConstraint {
             left: self.left.resolve_expr(bindings),
             right: self.right.resolve_expr(bindings),
-            ..self.clone()
+            ..self
         }
     }
 }
@@ -246,7 +246,7 @@ impl Constraint {
         }
     }
 
-    pub fn resolve_event(&self, binding: &Binding<Time>) -> Constraint {
+    pub fn resolve_event(self, binding: &Binding<Time>) -> Constraint {
         match self {
             Constraint::Base { base } => Constraint::Base {
                 base: base.resolve_event(binding),
@@ -257,7 +257,7 @@ impl Constraint {
         }
     }
 
-    pub fn resolve_expr(&self, bindings: &Binding<Expr>) -> Self {
+    pub fn resolve_expr(self, bindings: &Binding<Expr>) -> Self {
         match self {
             Constraint::Base { base } => Constraint::Base {
                 base: base.resolve_expr(bindings),

--- a/src/core/control.rs
+++ b/src/core/control.rs
@@ -524,11 +524,17 @@ pub struct Bundle {
     pub len: Expr,
     /// Type of the bundle
     pub typ: BundleType,
+    pos: GPosIdx,
 }
 
 impl Bundle {
     pub fn new(name: Id, len: Expr, typ: BundleType) -> Self {
-        Self { name, len, typ }
+        Self {
+            name,
+            len,
+            typ,
+            pos: GPosIdx::UNKNOWN,
+        }
     }
 
     /// Generate a port definition corresponding to a given index
@@ -545,10 +551,21 @@ impl Bundle {
     /// Resolve expressions in the Bundle
     pub fn resolve_exprs(self, binding: &Binding<Expr>) -> Self {
         Self {
-            name: self.name,
             len: self.len.resolve(binding),
             typ: self.typ.resolve_exprs(binding),
+            ..self
         }
+    }
+}
+
+impl WithPos for Bundle {
+    fn set_span(mut self, sp: GPosIdx) -> Self {
+        self.pos = sp;
+        self
+    }
+
+    fn copy_span(&self) -> GPosIdx {
+        self.pos
     }
 }
 

--- a/src/core/control.rs
+++ b/src/core/control.rs
@@ -537,7 +537,7 @@ impl Bundle {
         bind.insert(self.typ.idx.clone(), idx);
         PortDef::new(
             "__FAKE_NAME_SHOULD_NOT_BE_USED".into(),
-            self.typ.liveness.resolve_exprs(&bind),
+            self.typ.liveness.clone().resolve_exprs(&bind),
             self.typ.bitwidth.clone(),
         )
     }

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -65,7 +65,7 @@ impl Expr {
     }
 
     /// Resolve this expression using the given binding for abstract variables.
-    pub fn resolve(&self, bind: &utils::Binding<Expr>) -> Self {
+    pub fn resolve(self, bind: &utils::Binding<Expr>) -> Self {
         todo!()
     }
 

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -3,61 +3,85 @@ use crate::utils::{self, SExp};
 use itertools::Itertools;
 use std::fmt::Display;
 
-#[derive(Default, Clone, PartialEq, Eq, Hash)]
-/// An expression representing the sum of concrete numbers and abstract variables.
-/// Comparison between two [Expr] does not take into account the order of the
-/// variables.
-pub struct Expr {
-    // Concrete part of the time sum
-    concrete: u64,
-    // Abstract part of the time sum
-    abs: Vec<Id>,
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd)]
+pub enum Op {
+    Add,
+    Sub,
+    Mul,
+}
+
+impl Display for Op {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Op::Add => write!(f, "+"),
+            Op::Sub => write!(f, "-"),
+            Op::Mul => write!(f, "*"),
+        }
+    }
+}
+
+#[derive(Clone, Hash)]
+pub enum Expr {
+    Concrete(u64),
+    Abstract(Id),
+    Op {
+        op: Op,
+        left: Box<Expr>,
+        right: Box<Expr>,
+    },
+}
+
+impl Default for Expr {
+    fn default() -> Self {
+        Expr::Concrete(0)
+    }
+}
+
+impl TryFrom<Expr> for u64 {
+    type Error = ();
+
+    fn try_from(value: Expr) -> Result<Self, Self::Error> {
+        match value {
+            Expr::Concrete(n) => Ok(n),
+            _ => Err(()),
+        }
+    }
+}
+impl TryFrom<&Expr> for u64 {
+    type Error = ();
+
+    fn try_from(value: &Expr) -> Result<Self, Self::Error> {
+        match value {
+            Expr::Concrete(n) => Ok(*n),
+            _ => Err(()),
+        }
+    }
 }
 
 impl Expr {
-    pub fn new(concrete: u64, abs: Vec<Id>) -> Self {
-        Self {
-            concrete,
-            abs: abs.into_iter().collect(),
-        }
-    }
-
-    // Attempt to transform this in to a concrete time.
-    // Panics if there are abstract values.
-    pub fn concrete(&self) -> Option<u64> {
-        if self.abs.is_empty() {
-            Some(self.concrete)
-        } else {
-            None
-        }
+    /// Construct a new expression from a concrete value
+    pub fn concrete(n: u64) -> Self {
+        Expr::Concrete(n)
     }
 
     /// Resolve this expression using the given binding for abstract variables.
     pub fn resolve(&self, bind: &utils::Binding<Expr>) -> Self {
-        let mut offset = Expr {
-            concrete: self.concrete,
-            abs: vec![],
-        };
-
-        for x in &self.abs {
-            if let Some(sum) = bind.find(x) {
-                offset += sum.clone();
-            } else {
-                offset.abs.push(x.clone());
-            }
-        }
-
-        offset
+        todo!()
     }
 
     /// Check if this TimeSum is equal to 0
     pub fn is_zero(&self) -> bool {
-        self.concrete == 0 && self.abs.is_empty()
+        matches!(self, Expr::Concrete(0))
     }
 
     /// Get all the abstract variables in this expression
     pub fn exprs(&self) -> &Vec<Id> {
-        &self.abs
+        todo!()
+    }
+
+    /// Attempt to simplify this expression
+    pub fn simplify(self) -> SimplifiedExpr {
+        todo!()
     }
 }
 
@@ -65,139 +89,103 @@ impl std::ops::Add for Expr {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
-        Self {
-            concrete: self.concrete + rhs.concrete,
-            abs: self.abs.into_iter().chain(rhs.abs.into_iter()).collect(),
+        Self::Op {
+            op: Op::Add,
+            left: Box::new(self),
+            right: Box::new(rhs),
         }
     }
 }
 
 impl std::ops::AddAssign for Expr {
     fn add_assign(&mut self, rhs: Self) {
-        self.concrete += rhs.concrete;
-        self.abs.extend(rhs.abs);
+        todo!()
     }
 }
 
 impl std::ops::Sub for Expr {
-    /// Return the difference and optionally the "residual" if the subtraction needs to
-    /// represent some concrete or abstract values not on the left hand hide.
-    /// For example:
-    ///   L+1 - (W+2) => (L, Some(W+1))
-    type Output = (Expr, Option<Expr>);
+    type Output = Expr;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        // If the LHS concrete is bigger, then there is no residual
-        let (concrete, residual) = if self.concrete >= rhs.concrete {
-            (self.concrete - rhs.concrete, 0)
-        } else {
-            (0, rhs.concrete - self.concrete)
-        };
-
-        // Each time a variable occurs in the RHS, remove it from the LHS
-        let mut left = self.abs;
-        let mut right = vec![];
-        for x in rhs.abs {
-            if let Some(i) = left.iter().position(|y| *y == x) {
-                left.remove(i);
-            } else {
-                right.push(x);
-            }
-        }
-        if right.is_empty() && residual == 0 {
-            (Expr::new(concrete, left), None)
-        } else {
-            (Expr::new(concrete, left), Some(Expr::new(residual, right)))
-        }
-    }
-}
-
-impl PartialOrd for Expr {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let s1 = self.abs.iter().sorted().collect_vec();
-        let s2 = other.abs.iter().sorted().collect_vec();
-        if s1 == s2 {
-            self.concrete.partial_cmp(&other.concrete)
-        } else {
-            None
+        Self::Op {
+            op: Op::Sub,
+            left: Box::new(self),
+            right: Box::new(rhs),
         }
     }
 }
 
 impl Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.abs.is_empty() {
-            write!(f, "{}", self.concrete)
-        } else {
-            self.abs
-                .iter()
-                .map(|t| format!("#{t}"))
-                .chain(
-                    std::iter::once(self.concrete)
-                        .filter(|c| *c != 0)
-                        .map(|t| t.to_string()),
-                )
-                .join("+")
-                .fmt(f)
+        match self {
+            Expr::Concrete(n) => write!(f, "{}", n),
+            Expr::Abstract(id) => write!(f, "{}", id),
+            Expr::Op { op, left, right } => {
+                write!(f, "({} {} {})", op, left, right)
+            }
         }
     }
 }
 
 impl From<Expr> for utils::SExp {
     fn from(value: Expr) -> Self {
-        utils::SExp(format!(
-            "(+ {} {})",
-            value.abs.iter().map(|t| t.as_ref()).join(" "),
-            value.concrete
-        ))
+        todo!()
+        // utils::SExp(format!(
+        //     "(+ {} {})",
+        //     value.abs.iter().map(|t| t.as_ref()).join(" "),
+        //     value.concrete
+        // ))
     }
 }
 
 impl From<Vec<u64>> for Expr {
     fn from(v: Vec<u64>) -> Self {
-        Self {
-            concrete: v.iter().sum(),
-            abs: vec![],
-        }
+        Self::concrete(v.iter().sum())
     }
 }
 
 impl From<u64> for Expr {
     fn from(v: u64) -> Self {
-        Self {
-            concrete: v,
-            abs: vec![],
-        }
+        Self::concrete(v)
     }
 }
 
 impl From<Id> for Expr {
     fn from(v: Id) -> Self {
-        Self {
-            concrete: 0,
-            abs: vec![v],
-        }
+        Self::Abstract(v)
     }
 }
 
 impl From<Time> for SExp {
     fn from(t: Time) -> SExp {
-        if t.offset().abs.is_empty() && t.offset().concrete == 0 {
-            SExp(format!("{}", t.event))
-        } else if t.offset().abs.is_empty() {
-            SExp(format!("(+ {} {})", t.event, t.offset().concrete))
-        } else {
-            SExp(format!(
-                "(+ {} {} {})",
-                t.event,
-                t.offset().concrete,
-                t.offset()
-                    .abs
-                    .iter()
-                    .map(|e| e.to_string())
-                    .collect_vec()
-                    .join(" ")
-            ))
-        }
+        todo!()
+        // if t.offset().abs.is_empty() && t.offset().concrete == 0 {
+        //     SExp(format!("{}", t.event))
+        // } else if t.offset().abs.is_empty() {
+        //     SExp(format!("(+ {} {})", t.event, t.offset().concrete))
+        // } else {
+        //     SExp(format!(
+        //         "(+ {} {} {})",
+        //         t.event,
+        //         t.offset().concrete,
+        //         t.offset()
+        //             .abs
+        //             .iter()
+        //             .map(|e| e.to_string())
+        //             .collect_vec()
+        //             .join(" ")
+        //     ))
+        // }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// An expression that has been simplified and canonicalized.
+/// Supports efficient comparison and ordering operations.
+pub struct SimplifiedExpr;
+
+impl Display for SimplifiedExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
     }
 }

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -1,5 +1,5 @@
-use super::Id;
-use crate::utils;
+use super::{Id, Time};
+use crate::utils::{self, SExp};
 use itertools::Itertools;
 use std::fmt::Display;
 
@@ -9,9 +9,9 @@ use std::fmt::Display;
 /// variables.
 pub struct Expr {
     // Concrete part of the time sum
-    pub concrete: u64,
+    concrete: u64,
     // Abstract part of the time sum
-    pub abs: Vec<Id>,
+    abs: Vec<Id>,
 }
 
 impl Expr {
@@ -176,6 +176,28 @@ impl From<Id> for Expr {
         Self {
             concrete: 0,
             abs: vec![v],
+        }
+    }
+}
+
+impl From<Time> for SExp {
+    fn from(t: Time) -> SExp {
+        if t.offset().abs.is_empty() && t.offset().concrete == 0 {
+            SExp(format!("{}", t.event))
+        } else if t.offset().abs.is_empty() {
+            SExp(format!("(+ {} {})", t.event, t.offset().concrete))
+        } else {
+            SExp(format!(
+                "(+ {} {} {})",
+                t.event,
+                t.offset().concrete,
+                t.offset()
+                    .abs
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect_vec()
+                    .join(" ")
+            ))
         }
     }
 }

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -5,7 +5,7 @@ use crate::{
 use derivative::Derivative;
 
 #[derive(Derivative, Clone)]
-#[derivative(Hash, Eq, Debug, PartialOrd, Ord)]
+#[derivative(Hash, Eq, PartialOrd, Ord)]
 pub struct Id {
     id: GSym,
     #[derivative(Hash = "ignore")]
@@ -45,6 +45,15 @@ impl Default for Id {
 }
 
 impl std::fmt::Display for Id {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.id)
+    }
+}
+
+impl std::fmt::Debug for Id {
     fn fmt(
         &self,
         f: &mut std::fmt::Formatter<'_>,

--- a/src/core/interval.rs
+++ b/src/core/interval.rs
@@ -6,12 +6,10 @@ use derivative::Derivative;
 use std::fmt::Display;
 
 /// A range over time representation
-#[derive(Clone, Derivative)]
-#[derivative(PartialEq)]
+#[derive(Clone)]
 pub struct Range {
     pub start: Time,
     pub end: Time,
-    #[derivative(PartialEq = "ignore")]
     pos: GPosIdx,
 }
 

--- a/src/core/interval.rs
+++ b/src/core/interval.rs
@@ -2,7 +2,6 @@ use super::{Constraint, Expr, OrderConstraint, Time, TimeSub};
 use crate::diagnostics::Diagnostics;
 use crate::utils::Binding;
 use crate::{errors, utils::GPosIdx};
-use derivative::Derivative;
 use std::fmt::Display;
 
 /// A range over time representation

--- a/src/core/interval.rs
+++ b/src/core/interval.rs
@@ -32,20 +32,20 @@ impl Range {
     }
 
     /// Resolve events mentioned in this range
-    pub fn resolve_event(&self, bindings: &Binding<Time>) -> Self {
+    pub fn resolve_event(self, bindings: &Binding<Time>) -> Self {
         Range {
             start: self.start.resolve_event(bindings),
             end: self.end.resolve_event(bindings),
-            ..self.clone()
+            ..self
         }
     }
 
     /// Resolve [Expr] mentioned in this range.
-    pub fn resolve_exprs(&self, bindings: &Binding<Expr>) -> Self {
+    pub fn resolve_exprs(self, bindings: &Binding<Expr>) -> Self {
         Range {
             start: self.start.resolve_expr(bindings),
             end: self.end.resolve_expr(bindings),
-            ..self.clone()
+            ..self
         }
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,7 +15,7 @@ pub use control::{
     Bundle, BundleType, Command, Connect, ForLoop, Fsm, Guard, Instance,
     Invoke, Port, PortType,
 };
-pub use expr::{Expr, SimplifiedExpr};
+pub use expr::Expr;
 pub use id::Id;
 pub use interval::Range;
 pub use port::{InterfaceDef, PortDef};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,7 +15,7 @@ pub use control::{
     Bundle, BundleType, Command, Connect, ForLoop, Fsm, Guard, Instance,
     Invoke, Port, PortType,
 };
-pub use expr::Expr;
+pub use expr::{Expr, Op};
 pub use id::Id;
 pub use interval::Range;
 pub use port::{InterfaceDef, PortDef};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,7 +15,7 @@ pub use control::{
     Bundle, BundleType, Command, Connect, ForLoop, Fsm, Guard, Instance,
     Invoke, Port, PortType,
 };
-pub use expr::Expr;
+pub use expr::{Expr, SimplifiedExpr};
 pub use id::Id;
 pub use interval::Range;
 pub use port::{InterfaceDef, PortDef};

--- a/src/core/port.rs
+++ b/src/core/port.rs
@@ -42,10 +42,10 @@ impl WithPos for PortDef {
 }
 impl PortDef {
     /// Resolves all time expressions in this port definition
-    pub fn resolve_event(&self, bindings: &Binding<Time>) -> Self {
+    pub fn resolve_event(self, bindings: &Binding<Time>) -> Self {
         Self {
             liveness: self.liveness.resolve_event(bindings),
-            ..(self.clone())
+            ..self
         }
     }
 
@@ -53,11 +53,11 @@ impl PortDef {
     /// Specifically:
     /// - The bitwidth of the port
     /// - The liveness condition
-    pub fn resolve_offset(&self, bindings: &Binding<Expr>) -> Self {
+    pub fn resolve_offset(self, bindings: &Binding<Expr>) -> Self {
         Self {
             bitwidth: self.bitwidth.resolve(bindings),
             liveness: self.liveness.resolve_exprs(bindings),
-            ..(self.clone())
+            ..self
         }
     }
 }

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -45,14 +45,14 @@ impl Time {
     }
 
     /// Resolve the events bound in this time expression
-    pub fn resolve_event(&self, bindings: &utils::Binding<Self>) -> Self {
+    pub fn resolve_event(self, bindings: &utils::Binding<Self>) -> Self {
         let mut n = bindings.get(&self.event).clone();
-        n.offset += self.offset.clone();
+        n.offset += self.offset;
         n
     }
 
     /// Resolve all expressions bound in this time expression
-    pub fn resolve_expr(&self, bind: &utils::Binding<Expr>) -> Self {
+    pub fn resolve_expr(self, bind: &utils::Binding<Expr>) -> Self {
         Time {
             event: self.event.clone(),
             offset: self.offset.resolve(bind),
@@ -139,7 +139,7 @@ impl TimeSub {
     }
 
     /// Resolve events bound in this time expression
-    pub fn resolve_event(&self, bindings: &utils::Binding<Time>) -> Self {
+    pub fn resolve_event(self, bindings: &utils::Binding<Time>) -> Self {
         match self {
             // Unit cannot contain any events
             TimeSub::Unit(_) => self.clone(),
@@ -149,7 +149,7 @@ impl TimeSub {
         }
     }
 
-    pub fn resolve_expr(&self, bindings: &utils::Binding<Expr>) -> Self {
+    pub fn resolve_expr(self, bindings: &utils::Binding<Expr>) -> Self {
         match self {
             TimeSub::Unit(n) => TimeSub::Unit(n.resolve(bindings)),
             TimeSub::Sym { l, r } => {

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -63,16 +63,17 @@ impl Time {
     pub fn event(&self) -> Id {
         self.event.clone()
     }
-
-    /// Abstract expressions in this time expression
-    pub fn exprs(&self) -> &Vec<Id> {
-        self.offset.exprs()
-    }
 }
 
 impl From<Id> for Time {
     fn from(event: Id) -> Self {
         Time::unit(event, 0)
+    }
+}
+
+impl From<Time> for SExp {
+    fn from(value: Time) -> Self {
+        SExp(format!("(+ {} {})", value.event, SExp::from(value.offset)))
     }
 }
 

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -181,7 +181,11 @@ impl TimeSub {
 impl Display for TimeSub {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TimeSub::Unit(n) => write!(f, "|{}|", n),
+            TimeSub::Unit(n) => match n {
+                Expr::Concrete(n) => write!(f, "{}", n),
+                Expr::Abstract(id) => write!(f, "{}", id),
+                n => write!(f, "|{}|", n),
+            },
             TimeSub::Sym { l, r } => write!(f, "|{} - {}|", l, r),
         }
     }

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -1,6 +1,5 @@
 use super::{Expr, Id, Range};
 use crate::utils::{self, SExp};
-use itertools::Itertools;
 use std::fmt::Display;
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd)]
@@ -48,8 +47,7 @@ impl Time {
     /// Resolve the events bound in this time expression
     pub fn resolve_event(&self, bindings: &utils::Binding<Self>) -> Self {
         let mut n = bindings.get(&self.event).clone();
-        n.offset.concrete += self.offset.concrete;
-        n.offset.abs.extend(self.offset.abs.clone());
+        n.offset += self.offset.clone();
         n
     }
 
@@ -75,28 +73,6 @@ impl Time {
 impl From<Id> for Time {
     fn from(event: Id) -> Self {
         Time::unit(event, 0)
-    }
-}
-
-impl From<Time> for SExp {
-    fn from(t: Time) -> SExp {
-        if t.offset.abs.is_empty() && t.offset.concrete == 0 {
-            SExp(format!("{}", t.event))
-        } else if t.offset.abs.is_empty() {
-            SExp(format!("(+ {} {})", t.event, t.offset.concrete))
-        } else {
-            SExp(format!(
-                "(+ {} {} {})",
-                t.event,
-                t.offset.concrete,
-                t.offset
-                    .abs
-                    .iter()
-                    .map(|e| e.to_string())
-                    .collect_vec()
-                    .join(" ")
-            ))
-        }
     }
 }
 

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -181,7 +181,7 @@ impl TimeSub {
 impl Display for TimeSub {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TimeSub::Unit(n) => write!(f, "{}", n),
+            TimeSub::Unit(n) => write!(f, "|{}|", n),
             TimeSub::Sym { l, r } => write!(f, "|{} - {}|", l, r),
         }
     }
@@ -190,7 +190,7 @@ impl Display for TimeSub {
 impl From<TimeSub> for SExp {
     fn from(ts: TimeSub) -> Self {
         match ts {
-            TimeSub::Unit(n) => n.into(),
+            TimeSub::Unit(n) => SExp(format!("(abs {})", SExp::from(n))),
             TimeSub::Sym { l, r } => {
                 SExp(format!("(abs (- {} {}))", SExp::from(l), SExp::from(r)))
             }

--- a/src/diagnostics/reporter.rs
+++ b/src/diagnostics/reporter.rs
@@ -139,3 +139,13 @@ impl Diagnostics {
         Some(total)
     }
 }
+
+impl Drop for Diagnostics {
+    fn drop(&mut self) {
+        if let Some(errs) = self.report_all() {
+            if std::thread::panicking() {
+                eprintln!("{errs} errors encountered before panic");
+            }
+        }
+    }
+}

--- a/src/expr_simplifier.rs
+++ b/src/expr_simplifier.rs
@@ -1,0 +1,64 @@
+use egg::{
+    self, define_language, rewrite, AstSize, Extractor, Id, RecExpr, Rewrite,
+    Runner, Symbol,
+};
+
+define_language! {
+    enum ExprLang {
+        Num(u64),
+        Abstract(Symbol),
+        "+" = Add([Id; 2]),
+        "-" = Sub([Id; 2]),
+        "*" = Mul([Id; 2]),
+        "/" = Div([Id; 2]),
+    }
+}
+
+fn make_rules() -> Vec<Rewrite<ExprLang, ()>> {
+    vec![
+        // Commute rules
+        rewrite!("commute-add"; "(+ ?a ?b)" => "(+ ?b ?a)"),
+        rewrite!("commute-mul"; "(* ?a ?b)" => "(* ?b ?a)"),
+        // Identity rules
+        rewrite!("add-0"; "(+ ?a 0)" => "?a"),
+        rewrite!("sub-0"; "(- ?a 0)" => "?a"),
+        rewrite!("mul-1"; "(* ?a 1)" => "?a"),
+        rewrite!("div-1"; "(/ ?a 1)" => "?a"),
+        // Absorption rules
+        rewrite!("mul-0"; "(* ?a 0)" => "0"),
+        rewrite!("div-0"; "(/ 0 ?a)" => "0"),
+        rewrite!("sub-inv"; "(- ?a ?a)" => "0"),
+        // Inverse rules
+        rewrite!("add-neg"; "(+ ?a (- ?a ?b))" => "?b"),
+        rewrite!("add-neg-rev"; "(- (+ ?a ?b) ?a)" => "?b"),
+        // Distributive rules
+        rewrite!("mul-div"; "(* ?a (/ ?b ?c))" => "(* (/ ?a ?c) ?b)"),
+        rewrite!("distrib-mul-add"; "(* ?a (+ ?b ?c))" => "(+ (* ?a ?b) (* ?a ?c))"),
+        rewrite!("distrib-mul-sub"; "(* ?a (- ?b ?c))" => "(- (* ?a ?b) (* ?a ?c))"),
+        rewrite!("distrib-div-add"; "(/ (+ ?a ?b) ?c)" => "(+ (/ ?a ?c) (/ ?b ?c))"),
+        rewrite!("distrib-div-sub"; "(/ (- ?a ?b) ?c)" => "(- (/ ?a ?c) (/ ?b ?c))"),
+    ]
+}
+
+pub struct Simplifier;
+
+impl Simplifier {
+    /// parse an expression, simplify it using egg, and pretty print it back out
+    pub fn simplify(s: &str) -> String {
+        // parse the expression, the type annotation tells it which Language to use
+        let expr: RecExpr<ExprLang> = s.parse().unwrap();
+
+        // simplify the expression using a Runner, which creates an e-graph with
+        // the given expression and runs the given rules over it
+        let runner = Runner::default().with_expr(&expr).run(&make_rules());
+
+        // the Runner knows which e-class the expression given with `with_expr` is in
+        let root = runner.roots[0];
+
+        // use an Extractor to pick the best element of the root eclass
+        let extractor = Extractor::new(&runner.egraph, AstSize);
+        let (best_cost, best) = extractor.find_best(root);
+        println!("Simplified {} to {} with cost {}", expr, best, best_cost);
+        best.to_string()
+    }
+}

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -193,7 +193,7 @@ impl FilamentParser {
                 Ok(Port::Int(core::InterfaceDef::new(name, time_var).set_span(sp)))
             },
             [identifier(name), expr(bitwidth)] => {
-                match bitwidth.concrete() {
+                match (&bitwidth).try_into().ok() {
                     Some(n) => Ok(Port::Un((name, n))),
                     None => Err(input.error("Port width must be concrete")),
                 }

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -176,8 +176,8 @@ impl FilamentParser {
                 let mut ts = core::Expr::default();
                 for e in es {
                     match e {
-                        ConstOrVar::Const(c) => { ts.concrete += c; },
-                        ConstOrVar::Var(v) => { ts.abs.push(v); },
+                        ConstOrVar::Const(c) => { ts += c.into(); },
+                        ConstOrVar::Var(v) => { ts += v.into(); },
                     }
                 }
                 ts

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -46,11 +46,6 @@ pub enum Port {
     Un((core::Id, u64)),
 }
 
-pub enum ConstOrVar {
-    Const(u64),
-    Var(core::Id),
-}
-
 #[derive(Parser)]
 #[grammar = "frontend/syntax.pest"]
 pub struct FilamentParser;

--- a/src/frontend/syntax.pest
+++ b/src/frontend/syntax.pest
@@ -65,11 +65,19 @@ param_var = ${ pound ~ identifier }
 interface = {
   "@interface" ~ "[" ~ identifier ~ "]"
 }
-conc_or_var = {
-  bitwidth | param_var
+op_mul = { "*" }
+op_div = { "/" }
+op_add = { "+" }
+op_sub = { "-" }
+operator = _{ op_mul | op_div | op_add | op_sub }
+
+expr_base = {
+  | "(" ~ expr ~ ")"
+  | bitwidth
+  | param_var
 }
 expr = {
-  conc_or_var ~ ("+" ~ conc_or_var)*
+  expr_base ~ (operator ~ expr_base)*
 }
 
 // Event bindings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,6 @@ pub mod utils;
 pub mod visitor;
 
 pub(crate) mod core;
-pub(crate) mod expr_simplifier;
+// pub(crate) mod expr_simplifier;
 
 pub use diagnostics::errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod backend;
 pub mod binding;
 pub mod cmdline;
-pub(crate) mod core;
 pub mod diagnostics;
 pub mod frontend;
 pub mod passes;
 pub mod resolver;
 pub mod utils;
 pub mod visitor;
+
+pub(crate) mod core;
+pub(crate) mod expr_simplifier;
 
 pub use diagnostics::errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ fn run(opts: &cmdline::Opts) -> Result<(), u64> {
     // enable tracing
     env_logger::Builder::from_default_env()
         .format_timestamp(None)
-        // .format_module_path(false)
-        // .format_target(false)
+        .format_module_path(false)
+        .format_target(false)
         // .filter_level(opts.log_level)
         .target(env_logger::Target::Stderr)
         .init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,11 @@ use std::time::Instant;
 // Prints out the interface for main component in the input program.
 fn run(opts: &cmdline::Opts) -> Result<(), u64> {
     // enable tracing
-    env_logger::Builder::new()
+    env_logger::Builder::from_default_env()
         .format_timestamp(None)
-        .format_module_path(false)
-        .format_target(false)
-        .filter_level(opts.log_level)
+        // .format_module_path(false)
+        // .format_target(false)
+        // .filter_level(opts.log_level)
         .target(env_logger::Target::Stderr)
         .init();
 

--- a/src/passes/bind_check.rs
+++ b/src/passes/bind_check.rs
@@ -234,21 +234,21 @@ impl visitor::Checker for BindCheck {
 
     fn connect(
         &mut self,
-        con: &core::Connect,
-        ctx: &binding::CompBinding,
+        _con: &core::Connect,
+        _ctx: &binding::CompBinding,
     ) -> Traverse {
-        let resolve =
+        let _resolve =
             |r: &core::Range,
              _: &utils::Binding<core::Time>,
              _: &utils::Binding<core::Expr>| r.clone();
-        let dst_w = ctx
-            .get_resolved_port(&con.dst, resolve)
-            .map(|p| p.bitwidth)
-            .unwrap_or_else(|| 32.into());
-        let src_w = ctx
-            .get_resolved_port(&con.src, resolve)
-            .map(|p| p.bitwidth)
-            .unwrap_or_else(|| 32.into());
+        // let dst_w = ctx
+        //     .get_resolved_port(&con.dst, resolve)
+        //     .map(|p| p.bitwidth)
+        //     .unwrap_or_else(|| 32.into());
+        // let src_w = ctx
+        //     .get_resolved_port(&con.src, resolve)
+        //     .map(|p| p.bitwidth)
+        //     .unwrap_or_else(|| 32.into());
 
         // XXX(rachit): This cannot be checked locally. We need to generate constraints in the interval checker to check this property.
         // if dst_w != ss {

--- a/src/passes/bind_check.rs
+++ b/src/passes/bind_check.rs
@@ -250,17 +250,16 @@ impl visitor::Checker for BindCheck {
             .map(|p| p.bitwidth)
             .unwrap_or_else(|| 32.into());
 
-        if dst_w != src_w {
+        let ds = dst_w.simplify();
+        let ss = src_w.simplify();
+        if ds != ss {
             let err = Error::malformed("port width mismatch".to_string())
                 .add_note(self.diag.add_info(
-                    format!("source `{}' has width {src_w}", con.src.name()),
+                    format!("source `{}' has width {ss}", con.src.name()),
                     con.src.copy_span(),
                 ))
                 .add_note(self.diag.add_info(
-                    format!(
-                        "destination `{}' has width {dst_w}",
-                        con.dst.name(),
-                    ),
+                    format!("destination `{}' has width {ds}", con.dst.name(),),
                     con.dst.copy_span(),
                 ));
             self.diag.add_error(err);

--- a/src/passes/bind_check.rs
+++ b/src/passes/bind_check.rs
@@ -250,21 +250,19 @@ impl visitor::Checker for BindCheck {
             .map(|p| p.bitwidth)
             .unwrap_or_else(|| 32.into());
 
-        let ds = dst_w.simplify();
-        let ss = src_w.simplify();
         // XXX(rachit): This cannot be checked locally. We need to generate constraints in the interval checker to check this property.
-        if ds != ss {
-            let err = Error::malformed("port width mismatch".to_string())
-                .add_note(self.diag.add_info(
-                    format!("source `{}' has width {ss}", con.src.name()),
-                    con.src.copy_span(),
-                ))
-                .add_note(self.diag.add_info(
-                    format!("destination `{}' has width {ds}", con.dst.name(),),
-                    con.dst.copy_span(),
-                ));
-            self.diag.add_error(err);
-        }
+        // if dst_w != ss {
+        //     let err = Error::malformed("port width mismatch".to_string())
+        //         .add_note(self.diag.add_info(
+        //             format!("source `{}' has width {ss}", con.src.name()),
+        //             con.src.copy_span(),
+        //         ))
+        //         .add_note(self.diag.add_info(
+        //             format!("destination `{}' has width {ds}", con.dst.name(),),
+        //             con.dst.copy_span(),
+        //         ));
+        //     self.diag.add_error(err);
+        // }
         Traverse::Continue(())
     }
 }

--- a/src/passes/bind_check.rs
+++ b/src/passes/bind_check.rs
@@ -252,6 +252,7 @@ impl visitor::Checker for BindCheck {
 
         let ds = dst_w.simplify();
         let ss = src_w.simplify();
+        // XXX(rachit): This cannot be checked locally. We need to generate constraints in the interval checker to check this property.
         if ds != ss {
             let err = Error::malformed("port width mismatch".to_string())
                 .add_note(self.diag.add_info(

--- a/src/passes/dump_interface.rs
+++ b/src/passes/dump_interface.rs
@@ -87,8 +87,8 @@ impl visitor::Transform for DumpInterface {
             format!(
                 "{{ \"event\": \"{event}\", \"name\": \"{name}\", \"width\": {w} , \"start\": {st}, \"end\": {end} }}",
                 name = pd.name,
-                st = st.concrete().unwrap(),
-                end = end.concrete().unwrap(),
+                st = u64::try_from(&st).unwrap(),
+                end = u64::try_from(&end).unwrap(),
             )
         };
 

--- a/src/passes/interval_checking/checker.rs
+++ b/src/passes/interval_checking/checker.rs
@@ -188,7 +188,7 @@ impl visitor::Checker for IntervalCheck {
             |r: &core::Range,
              event_b: &utils::Binding<Time>,
              param_b: &utils::Binding<core::Expr>| {
-                r.resolve_exprs(param_b).resolve_event(event_b)
+                r.clone().resolve_exprs(param_b).resolve_event(event_b)
             };
 
         let requirement =

--- a/src/passes/interval_checking/checker.rs
+++ b/src/passes/interval_checking/checker.rs
@@ -16,18 +16,28 @@ impl IntervalCheck {
         };
         let bun_idx = ctx.get_bundle_idx(name);
         let bun_len = &ctx[bun_idx].len;
-        let con = core::Constraint::sub(OrderConstraint::lt(
+        let greater = core::Constraint::sub(OrderConstraint::lt(
             idx.clone().into(),
             bun_len.clone().into(),
         ))
         .add_note(
             self.diag
                 .add_info(
-                    format!("cannot prove within-bounds bundle access: bundle of length {bun_len} with index {idx}"),
+                    format!("cannot prove within-bounds bundle access: index {idx} greater than bundle length {bun_len}"),
                     port.copy_span()
                 ),
         );
-        self.add_obligations(Some(con));
+        let smaller = core::Constraint::sub(OrderConstraint::gte(
+            idx.clone().into(),
+            core::Expr::from(0).into(),
+        )).add_note(
+            self.diag
+                .add_info(
+                    format!("cannot prove within-bounds bundle access: index {idx} less than 0"),
+                    port.copy_span()
+                ),
+        );
+        self.add_obligations([greater, smaller]);
     }
 
     fn check_width(

--- a/src/passes/interval_checking/context.rs
+++ b/src/passes/interval_checking/context.rs
@@ -134,17 +134,16 @@ impl IntervalCheck {
         }
 
         // Iterate over each event
-        let events = ctx.prog[ctx[inst].sig].events().collect_vec();
+        let event_binds = &ctx.prog[ctx[inst].sig].events;
         let mut share_constraints = Vec::new();
         let num_bindings = invoke_bindings.len();
-        for event in 0..events.len() {
+        for event in 0..event_binds.len() {
             // Build up a sharing constraint for each event in the signature.
             // Since all bindings use the same event, we can use the event mentioned in the first binding
             // as the one to use for the sharing constraint
             let bounded_event = first_bind[event].0.event();
             let this = ctx.this();
             let eb = this.get_event(&bounded_event).clone();
-            let eb_pos = eb.copy_span();
             let mut share = ShareConstraint::from(eb);
 
             // Iterate over all pairs of bindings
@@ -178,7 +177,7 @@ impl IntervalCheck {
                     )
                     .add_note(self.diag.add_info(
                         format!("delay requires {} cycle between event but reuse may occur after {} cycles", delay.clone(), start_i.clone() - start_k.clone()),
-                        eb_pos,
+                        event_binds[event].copy_span(),
                     ))
                     .add_note(self.diag.add_info(
                         format!("invocation starts at `{start_k}'"),

--- a/src/passes/max_states.rs
+++ b/src/passes/max_states.rs
@@ -26,7 +26,7 @@ impl MaxStates {
             for time in pd.liveness.time_exprs() {
                 let ev = &time.event;
                 let v = self.cur_states.get_mut(ev).unwrap();
-                let st = time.offset().concrete().unwrap();
+                let st = u64::try_from(time.offset()).unwrap();
                 if *v < st {
                     *v = st;
                 }

--- a/src/passes/monomorphize.rs
+++ b/src/passes/monomorphize.rs
@@ -114,16 +114,12 @@ impl Rewriter {
                         .into(),
                     )
                 }
-                core::Command::Bundle(core::Bundle { name, len, typ }) => {
-                    n_cmds.push(
-                        core::Bundle::new(
-                            self.binding[&name].clone(),
-                            len,
-                            typ,
-                        )
+                core::Command::Bundle(core::Bundle {
+                    name, len, typ, ..
+                }) => n_cmds.push(
+                    core::Bundle::new(self.binding[&name].clone(), len, typ)
                         .into(),
-                    )
-                }
+                ),
                 core::Command::ForLoop(_) => unreachable!(),
                 core::Command::Fsm(_) => unreachable!(),
             }

--- a/src/passes/monomorphize.rs
+++ b/src/passes/monomorphize.rs
@@ -170,7 +170,7 @@ impl InstanceParams {
             .map(|p| {
                 let abs = p.exprs();
                 match abs.len() {
-                    0 => vec![p.concrete().unwrap()],
+                    0 => vec![u64::try_from(p).unwrap()],
                     1 => self.param_values(parent, &abs[0]).collect(),
                     n => unreachable!("Cannot have more than one abstract parameter in a binding: {n}")
                 }
@@ -234,9 +234,9 @@ impl Monomorphize {
     ) -> core::Id {
         let mut name = String::from(comp.as_ref());
         for p in params {
-            match p.concrete() {
-                Some(p) => name += format!("_{}", p).as_str(),
-                None => {
+            match u64::try_from(p) {
+                Ok(p) => name += format!("_{}", p).as_str(),
+                Err(_) => {
                     unreachable!("Binding should only contain concrete values")
                 }
             }
@@ -351,14 +351,14 @@ impl Monomorphize {
                     ..
                 }) => {
                     // Compute the start and end values of the loop
-                    let s =
-                        start.resolve(param_binding).concrete().unwrap_or_else(
-                            || panic!("Loop start must be concrete"),
+                    let s: u64 =
+                        start.resolve(param_binding).try_into().unwrap_or_else(
+                            |_| panic!("Loop start must be concrete"),
                         );
-                    let e = end
-                        .resolve(param_binding)
-                        .concrete()
-                        .unwrap_or_else(|| panic!("Loop end must be concrete"));
+                    let e =
+                        end.resolve(param_binding).try_into().unwrap_or_else(
+                            |_| panic!("Loop end must be concrete"),
+                        );
 
                     for i in s..e {
                         let mut new_binding = (*param_binding).clone();

--- a/src/passes/monomorphize.rs
+++ b/src/passes/monomorphize.rs
@@ -168,10 +168,10 @@ impl InstanceParams {
         let all_binds = params
             .iter()
             .map(|p| {
-                let abs = p.exprs();
+                let abs = p.exprs().collect_vec();
                 match abs.len() {
                     0 => vec![u64::try_from(p).unwrap()],
-                    1 => self.param_values(parent, &abs[0]).collect(),
+                    1 => self.param_values(parent, abs[0]).collect(),
                     n => unreachable!("Cannot have more than one abstract parameter in a binding: {n}")
                 }
             })

--- a/src/passes/monomorphize.rs
+++ b/src/passes/monomorphize.rs
@@ -246,7 +246,7 @@ impl Monomorphize {
 
     fn sig(sig: &core::Signature, binding: &[core::Expr]) -> core::Signature {
         // XXX: Short-circuit if binding is empty
-        let mut nsig = sig.resolve_offset(binding);
+        let mut nsig = sig.clone().resolve_exprs(binding);
         nsig.name = Self::generate_mono_name(&sig.name, binding);
         nsig.params = vec![];
         nsig

--- a/src/passes/monomorphize.rs
+++ b/src/passes/monomorphize.rs
@@ -167,13 +167,14 @@ impl InstanceParams {
         // All possible values for each parameter computed by resolving each parameter that occurs in the binding
         let all_binds = params
             .iter()
-            .map(|p|
-                match p.abs.len() {
-                    0 => vec![p.concrete],
-                    1 => self.param_values(parent, &p.abs[0]).collect(),
+            .map(|p| {
+                let abs = p.exprs();
+                match abs.len() {
+                    0 => vec![p.concrete().unwrap()],
+                    1 => self.param_values(parent, &abs[0]).collect(),
                     n => unreachable!("Cannot have more than one abstract parameter in a binding: {n}")
                 }
-            )
+            })
             .multi_cartesian_product()
             .collect_vec();
 

--- a/src/utils/idx.rs
+++ b/src/utils/idx.rs
@@ -1,5 +1,12 @@
 use std::{marker::PhantomData, num::NonZeroU32};
 
+#[macro_export]
+macro_rules! idx {
+    ($name:ty) => {
+       $crate::utils::Idx<$name>
+    };
+}
+
 #[derive(Eq, Debug)]
 /// Wrapper around a newtyped index associated with a type-level tag.
 /// Since the type does not contain a value of type T, it is always copy.
@@ -45,7 +52,8 @@ impl<T> Idx<T> {
     pub fn get(self) -> usize {
         debug_assert!(
             self != Self::UNKNOWN,
-            "Attempting to convert unknown index"
+            "attempting to convert unknown index for type `{}'",
+            std::any::type_name::<T>(),
         );
         (self.idx.get() - 1) as usize
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,5 +12,5 @@ pub use gsym::GSym;
 pub use idx::Idx;
 pub use namegenerator::NameGenerator;
 pub use position::{FileIdx, GPosIdx, GlobalPositionTable, PosData};
-pub use post_order::PostOrder;
+pub use post_order::Traversal;
 pub use solver::{FilSolver, SExp, ShareConstraint};

--- a/src/utils/post_order.rs
+++ b/src/utils/post_order.rs
@@ -3,16 +3,16 @@ use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use topological_sort::{self, TopologicalSort};
 
-/// Defines a post-order traversal of the components.
+/// Defines a traversal of the components.
 /// There is an edge between src -> dst if `src` instantiates an instance of `dst`.
-pub struct PostOrder {
+pub struct Traversal {
     /// The namespace
     ns: core::Namespace,
     /// The post-order traversal
     order: TopologicalSort<usize>,
 }
 
-impl From<core::Namespace> for PostOrder {
+impl From<core::Namespace> for Traversal {
     /// Construct a post-order traversal over a namespace.
     fn from(ns: core::Namespace) -> Self {
         let externs: HashSet<_> =
@@ -63,8 +63,8 @@ fn process_cmd(
     }
 }
 
-impl PostOrder {
-    /// Apply a mutable function to each component in the post-order traversal.
+impl Traversal {
+    /// Apply a mutable function to each component in a post-order traversal.
     pub fn apply_post_order<F>(&mut self, mut upd: F)
     where
         F: FnMut(&mut core::Component),
@@ -76,7 +76,7 @@ impl PostOrder {
         }
     }
 
-    /// Apply a function to each component in the pre-order traversal.
+    /// Apply a function to each component in a pre-order traversal.
     pub fn apply_pre_order<F>(&mut self, mut upd: F)
     where
         F: FnMut(&mut core::Component),

--- a/src/utils/solver.rs
+++ b/src/utils/solver.rs
@@ -126,7 +126,6 @@ impl ShareConstraint {
     fn is_max_end(&self, time: &Time) -> Option<bool> {
         todo!()
         // for (end, _) in &self.ends {
-        //     todo!()
         //     match end {
         //         TimeDelSum::Time(t) => {
         //             // Return if t > time
@@ -292,7 +291,7 @@ impl FilSolver {
             let relevant_vars = fact
                 .exprs()
                 .into_iter()
-                .flat_map(|e| e.exprs().clone())
+                .flat_map(|e| e.exprs().cloned())
                 .unique()
                 .collect_vec();
             if let Some(model) = self.check_fact(fact.clone(), &relevant_vars) {

--- a/src/utils/solver.rs
+++ b/src/utils/solver.rs
@@ -103,7 +103,7 @@ impl ShareConstraint {
     // Check whether this is the minimum start time.
     // Returns None if the list contains incompatible times
     fn is_min_start(&self, time: &Time) -> Option<bool> {
-        todo!()
+        None
         // for (start, _) in &self.starts {
         //     if start.event != time.event {
         //         return None;
@@ -124,7 +124,7 @@ impl ShareConstraint {
     // Check whether this is the maximum end time.
     // Returns None if the list contains incompatible times
     fn is_max_end(&self, time: &Time) -> Option<bool> {
-        todo!()
+        None
         // for (end, _) in &self.ends {
         //     match end {
         //         TimeDelSum::Time(t) => {

--- a/src/utils/solver.rs
+++ b/src/utils/solver.rs
@@ -102,7 +102,7 @@ impl ShareConstraint {
 
     // Check whether this is the minimum start time.
     // Returns None if the list contains incompatible times
-    fn is_min_start(&self, time: &Time) -> Option<bool> {
+    fn is_min_start(&self, _: &Time) -> Option<bool> {
         None
         // for (start, _) in &self.starts {
         //     if start.event != time.event {
@@ -123,7 +123,7 @@ impl ShareConstraint {
 
     // Check whether this is the maximum end time.
     // Returns None if the list contains incompatible times
-    fn is_max_end(&self, time: &Time) -> Option<bool> {
+    fn is_max_end(&self, _: &Time) -> Option<bool> {
         None
         // for (end, _) in &self.ends {
         //     match end {

--- a/src/utils/solver.rs
+++ b/src/utils/solver.rs
@@ -103,39 +103,45 @@ impl ShareConstraint {
     // Check whether this is the minimum start time.
     // Returns None if the list contains incompatible times
     fn is_min_start(&self, time: &Time) -> Option<bool> {
-        for (start, _) in &self.starts {
-            match start.partial_cmp(time) {
-                Some(std::cmp::Ordering::Less) => {
-                    return Some(false);
-                }
-                None => {
-                    return None;
-                }
-                Some(_) => (),
-            }
-        }
-        Some(true)
+        todo!()
+        // for (start, _) in &self.starts {
+        //     if start.event != time.event {
+        //         return None;
+        //     }
+        //     match start.partial_cmp(time) {
+        //         Some(std::cmp::Ordering::Less) => {
+        //             return Some(false);
+        //         }
+        //         None => {
+        //             return None;
+        //         }
+        //         Some(_) => (),
+        //     }
+        // }
+        // Some(true)
     }
 
     // Check whether this is the maximum end time.
     // Returns None if the list contains incompatible times
     fn is_max_end(&self, time: &Time) -> Option<bool> {
-        for (end, _) in &self.ends {
-            match end {
-                TimeDelSum::Time(t) => {
-                    // Return if t > time
-                    if t.partial_cmp(time) == Some(std::cmp::Ordering::Greater)
-                    {
-                        return Some(false);
-                    }
-                }
-                // Cannot compare a sum with a time
-                TimeDelSum::Sum(_, _) => {
-                    return None;
-                }
-            }
-        }
-        Some(true)
+        todo!()
+        // for (end, _) in &self.ends {
+        //     todo!()
+        //     match end {
+        //         TimeDelSum::Time(t) => {
+        //             // Return if t > time
+        //             if t.partial_cmp(time) == Some(std::cmp::Ordering::Greater)
+        //             {
+        //                 return Some(false);
+        //             }
+        //         }
+        //         // Cannot compare a sum with a time
+        //         TimeDelSum::Sum(_, _) => {
+        //             return None;
+        //         }
+        //     }
+        // }
+        // Some(true)
     }
 
     /// Transform the share constraint into an error
@@ -264,7 +270,7 @@ impl FilSolver {
             return;
         }
 
-        let asserts = asserts.into_iter().unique().collect_vec();
+        let asserts = asserts.into_iter().collect_vec();
         self.s.push(1).unwrap();
         // Define all the constants
         let vars = vars.into_iter().collect_vec();

--- a/src/utils/solver.rs
+++ b/src/utils/solver.rs
@@ -286,7 +286,7 @@ impl FilSolver {
             let relevant_vars = fact
                 .exprs()
                 .into_iter()
-                .flat_map(|e| e.abs.clone())
+                .flat_map(|e| e.exprs().clone())
                 .unique()
                 .collect_vec();
             if let Some(model) = self.check_fact(fact.clone(), &relevant_vars) {

--- a/src/visitor/visit.rs
+++ b/src/visitor/visit.rs
@@ -143,7 +143,9 @@ where
                     core::Command::Connect(con) => pass.connect(con, &ctx)?,
                     core::Command::Fsm(fsm) => pass.fsm(fsm, &ctx)?,
                     core::Command::Bundle(bl) => pass.bundle(bl, &ctx)?,
-                    core::Command::ForLoop(_) => todo!("Transforming loops"),
+                    core::Command::ForLoop(_) => unreachable!(
+                        "Visitor does not support transforming programs"
+                    ),
                 };
                 n_cmds.extend(cmds);
             }

--- a/tests/errors/bundle.expect
+++ b/tests/errors/bundle.expect
@@ -1,11 +1,11 @@
 ---CODE---
 1
 ---STDERR---
-error: Cannot prove constraint #N > 1
+error: Cannot prove constraint N > 1
    ┌─ tests/errors/bundle.fil:10:5
    │
 10 │     f{1} = input;
-   │     ^^^^ cannot prove within-bounds bundle access: bundle of length #N with index 1
+   │     ^^^^ cannot prove within-bounds bundle access: index 1 greater than bundle length #N
    │
    = assignment violates constraint: N=1
 
@@ -18,31 +18,31 @@ error: Cannot prove constraint G+1 >= G+2
    │     destination's requirement @[G+1, G+2]
    │
 
-error: Cannot prove constraint G+#i >= G+#i+1
+error: Cannot prove constraint G+#i >= G+(#i+1)
    ┌─ tests/errors/bundle.fil:13:17
    │
 13 │         f{#i} = d.out;
-   │         -----   ^^^^^ source is available for @[G+#i+1, G+#i+2]
+   │         -----   ^^^^^ source is available for @[G+(#i+1), G+(#i+2)]
    │         │        
-   │         destination's requirement @[G+#i, G+#i+1]
+   │         destination's requirement @[G+#i, G+(#i+1)]
    │
    = assignment violates constraint: i=0
 
-error: Cannot prove constraint #N > #N+1
+error: Cannot prove constraint N > |(#N+1)|
    ┌─ tests/errors/bundle.fil:15:11
    │
 15 │     out = f{#N+1};
-   │           ^^^^^^^ cannot prove within-bounds bundle access: bundle of length #N with index #N+1
+   │           ^^^^^^^ cannot prove within-bounds bundle access: index (#N+1) greater than bundle length #N
    │
    = assignment violates constraint: N=1
 
-error: Cannot prove constraint G+#N >= G+#N+1
+error: Cannot prove constraint G+#N >= G+(#N+1)
    ┌─ tests/errors/bundle.fil:15:11
    │
 15 │     out = f{#N+1};
-   │     ---   ^^^^^^^ source is available for @[G+#N+1, G+#N+2]
+   │     ---   ^^^^^^^ source is available for @[G+(#N+1), G+((#N+1)+1)]
    │     │      
-   │     destination's requirement @[G+#N, G+#N+1]
+   │     destination's requirement @[G+#N, G+(#N+1)]
    │
    = assignment violates constraint: N=1
 

--- a/tests/errors/conflicting-use.expect
+++ b/tests/errors/conflicting-use.expect
@@ -1,16 +1,32 @@
 ---CODE---
 1
 ---STDERR---
-error: Cannot prove constraint 1 >= 2
-  ┌─ tests/errors/conflicting-use.fil:4:11
+error: Cannot prove constraint |(0-1)| >= 2
+  ┌─ ./primitives/sequential.fil:3:15
   │
-4 │ comp Main<G: 3>(
-  │           ^^^^ delay requires 2 cycle between event but reuse may occur after 1 cycles
-  ·
+3 │ comp Mult[#W]<G: 2>(
+  │               ^^^^ delay requires 2 cycle between event but reuse may occur after |(0-1)| cycles
+  │
+  ┌─ tests/errors/conflicting-use.fil:8:3
+  │
 8 │   m0 := M<G>(10, 20);
   │   ------------------- invocation starts at `G'
 9 │   m1 := M<G+1>(30, 40);
   │   --------------------- invocation starts at `G+1'
   │
 
-Compilation failed with 1 errors.
+error: Cannot prove constraint 1 >= 2
+  ┌─ tests/errors/conflicting-use.fil:9:3
+  │
+8 │   m0 := M<G>(10, 20);
+  │   ------------------- invocation starts at `G'
+9 │   m1 := M<G+1>(30, 40);
+  │   ^^^^^^^^^^^^^^^^^^^^^ invocation starts at `G+1'
+  │
+  ┌─ ./primitives/sequential.fil:3:15
+  │
+3 │ comp Mult[#W]<G: 2>(
+  │               ---- delay requires 2 cycle between event but reuse may occur after 1 cycles
+  │
+
+Compilation failed with 2 errors.

--- a/tests/errors/dynamic-share.expect
+++ b/tests/errors/dynamic-share.expect
@@ -12,77 +12,85 @@ error: Cannot prove constraint L = G
    = invocations of instance use multiple events in invocations: L and G. Sharing using multiple events is not supported.
 
 error: Cannot prove constraint |L - G| >= 1
-   ┌─ tests/errors/dynamic-share.fil:3:25
+   ┌─ ./primitives/core.fil:10:20
    │
- 3 │ comp Max_mult_add<G: 3, L: 3>(
-   │                         ^^^^ delay requires 1 cycle between event but reuse may occur after |L - G| cycles
-   ·
+10 │   comp Add[#WIDTH]<G: L-(G), ?L: 1=G+1>(
+   │                    ^^^^^^^^ delay requires 1 cycle between event but reuse may occur after |L - G| cycles
+   │
+   ┌─ tests/errors/dynamic-share.fil:12:3
+   │
 12 │   m1 := M<L>(c, d);
    │   ----------------- invocation starts at `L'
 13 │   m0 := M<G>(a, b);
    │   ----------------- invocation starts at `G'
    │
 
-error: Cannot prove constraint |L - G| >= 1
-   ┌─ tests/errors/dynamic-share.fil:3:25
-   │
- 3 │ comp Max_mult_add<G: 3, L: 3>(
-   │                         ^^^^ delay requires 1 cycle between event but reuse may occur after |L - G| cycles
-   ·
-12 │   m1 := M<L>(c, d);
-   │   ----------------- invocation starts at `L+1'
-13 │   m0 := M<G>(a, b);
-   │   ----------------- invocation starts at `G+1'
-   │
-
 error: Cannot prove constraint |G - L| >= 1
    ┌─ tests/errors/dynamic-share.fil:13:3
    │
- 3 │ comp Max_mult_add<G: 3, L: 3>(
-   │                         ---- delay requires 1 cycle between event but reuse may occur after |G - L| cycles
-   ·
 12 │   m1 := M<L>(c, d);
    │   ----------------- invocation starts at `L'
 13 │   m0 := M<G>(a, b);
    │   ^^^^^^^^^^^^^^^^^ invocation starts at `G'
    │
-
-error: Cannot prove constraint |G - L| >= 1
-   ┌─ tests/errors/dynamic-share.fil:3:25
+   ┌─ ./primitives/core.fil:10:20
    │
- 3 │ comp Max_mult_add<G: 3, L: 3>(
-   │                         ^^^^ delay requires 1 cycle between event but reuse may occur after |G - L| cycles
-   ·
+10 │   comp Add[#WIDTH]<G: L-(G), ?L: 1=G+1>(
+   │                    -------- delay requires 1 cycle between event but reuse may occur after |G - L| cycles
+   │
+
+error: Cannot prove constraint |L+1 - G+1| >= 1
+   ┌─ ./primitives/core.fil:10:30
+   │
+10 │   comp Add[#WIDTH]<G: L-(G), ?L: 1=G+1>(
+   │                              ^^^^^^^^^ delay requires 1 cycle between event but reuse may occur after |L+1 - G+1| cycles
+   │
+   ┌─ tests/errors/dynamic-share.fil:12:3
+   │
 12 │   m1 := M<L>(c, d);
    │   ----------------- invocation starts at `L+1'
 13 │   m0 := M<G>(a, b);
    │   ----------------- invocation starts at `G+1'
    │
 
-error: Cannot prove constraint 3 >= max(L+1) - min(G)
-   ┌─ tests/errors/dynamic-share.fil:3:25
+error: Cannot prove constraint |G+1 - L+1| >= 1
+   ┌─ tests/errors/dynamic-share.fil:13:3
    │
- 3 │ comp Max_mult_add<G: 3, L: 3>(
-   │                         ^^^^ event's delay must be longer than the difference between minimum start time and maximum end time of all invocations
-   ·
 12 │   m1 := M<L>(c, d);
-   │           - invocation ends at `L+1'
+   │   ----------------- invocation starts at `L+1'
 13 │   m0 := M<G>(a, b);
-   │           - invocation starts at `G'
+   │   ^^^^^^^^^^^^^^^^^ invocation starts at `G+1'
    │
-   = assignment violates constraint: G=0, L=3
+   ┌─ ./primitives/core.fil:10:30
+   │
+10 │   comp Add[#WIDTH]<G: L-(G), ?L: 1=G+1>(
+   │                              --------- delay requires 1 cycle between event but reuse may occur after |G+1 - L+1| cycles
+   │
 
-error: Cannot prove constraint 3 >= max(L+2) - min(G+1)
+error: Cannot prove constraint 3 >= max(L+1, G+1) - min(L, G)
    ┌─ tests/errors/dynamic-share.fil:3:25
    │
  3 │ comp Max_mult_add<G: 3, L: 3>(
    │                         ^^^^ event's delay must be longer than the difference between minimum start time and maximum end time of all invocations
    ·
 12 │   m1 := M<L>(c, d);
-   │           - invocation ends at `L+2'
+   │           - invocation starts at `L' and ends at `L+1'
 13 │   m0 := M<G>(a, b);
-   │           - invocation starts at `G+1'
+   │           - invocation starts at `G' and ends at `G+1'
    │
-   = assignment violates constraint: G=0, L=3
+   = assignment violates constraint: G=3, L=0
+
+error: Cannot prove constraint 3 >= max(L+2, G+2) - min(L+1, G+1)
+   ┌─ tests/errors/dynamic-share.fil:3:25
+   │
+ 3 │ comp Max_mult_add<G: 3, L: 3>(
+   │                         ^^^^ event's delay must be longer than the difference between minimum start time and maximum end time of all invocations
+   ·
+12 │   m1 := M<L>(c, d);
+   │           - invocation starts at `L+1' and ends at `L+2'
+13 │   m0 := M<G>(a, b);
+   │           - invocation starts at `G+1' and ends at `G+2'
+   │
+   = assignment violates constraint: G=3, L=0
 
 Compilation failed with 7 errors.

--- a/tests/errors/param-width.expect
+++ b/tests/errors/param-width.expect
@@ -1,7 +1,7 @@
 ---CODE---
 1
 ---STDERR---
-error: port width mismatch
+error: Cannot prove constraint 32 = W
    ┌─ tests/errors/param-width.fil:5:16
    │
  5 │     a0 := A<G>(a, a);
@@ -11,8 +11,10 @@ error: port width mismatch
    │
 11 │     @[G, L] left: #WIDTH,
    │             ---- destination `left' has width 32
+   │
+   = assignment violates constraint: W=0
 
-error: port width mismatch
+error: Cannot prove constraint 32 = W
    ┌─ tests/errors/param-width.fil:5:19
    │
  5 │     a0 := A<G>(a, a);
@@ -22,5 +24,7 @@ error: port width mismatch
    │
 12 │     @[G, L] right: #WIDTH,
    │             ----- destination `right' has width 32
+   │
+   = assignment violates constraint: W=0
 
 Compilation failed with 2 errors.

--- a/tests/errors/poly-mismatch.expect
+++ b/tests/errors/poly-mismatch.expect
@@ -5,25 +5,25 @@ error: Cannot prove constraint G+#W >= G+#N
    ┌─ tests/errors/poly-mismatch.fil:12:28
    │
 12 │     a := new Add[#W]<G+#W>(s.out, acc);
-   │                            ^^^^^ source is available for @[G+#N, G+#N+1]
+   │                            ^^^^^ source is available for @[G+#N, G+(#N+1)]
    │
    ┌─ ./primitives/core.fil:11:13
    │
 11 │     @[G, L] left: #WIDTH,
-   │             ---- destination's requirement @[G+#W, G+#W+1]
+   │             ---- destination's requirement @[G+#W, G+(#W+1)]
    │
    = assignment violates constraint: W=1, N=2
 
-error: Cannot prove constraint G+#N+1 >= G+#W+1
+error: Cannot prove constraint G+(#N+1) >= G+(#W+1)
    ┌─ tests/errors/poly-mismatch.fil:12:28
    │
 12 │     a := new Add[#W]<G+#W>(s.out, acc);
-   │                            ^^^^^ source is available for @[G+#N, G+#N+1]
+   │                            ^^^^^ source is available for @[G+#N, G+(#N+1)]
    │
    ┌─ ./primitives/core.fil:11:13
    │
 11 │     @[G, L] left: #WIDTH,
-   │             ---- destination's requirement @[G+#W, G+#W+1]
+   │             ---- destination's requirement @[G+#W, G+(#W+1)]
    │
    = assignment violates constraint: N=0, W=1
 
@@ -31,35 +31,35 @@ error: Cannot prove constraint G+#W >= G+#N
    ┌─ tests/errors/poly-mismatch.fil:12:35
    │
 12 │     a := new Add[#W]<G+#W>(s.out, acc);
-   │                                   ^^^ source is available for @[G+#N, G+#N+1]
+   │                                   ^^^ source is available for @[G+#N, G+(#N+1)]
    │
    ┌─ ./primitives/core.fil:12:13
    │
 12 │     @[G, L] right: #WIDTH,
-   │             ----- destination's requirement @[G+#W, G+#W+1]
+   │             ----- destination's requirement @[G+#W, G+(#W+1)]
    │
    = assignment violates constraint: W=1, N=2
 
-error: Cannot prove constraint G+#N+1 >= G+#W+1
+error: Cannot prove constraint G+(#N+1) >= G+(#W+1)
    ┌─ tests/errors/poly-mismatch.fil:12:35
    │
 12 │     a := new Add[#W]<G+#W>(s.out, acc);
-   │                                   ^^^ source is available for @[G+#N, G+#N+1]
+   │                                   ^^^ source is available for @[G+#N, G+(#N+1)]
    │
    ┌─ ./primitives/core.fil:12:13
    │
 12 │     @[G, L] right: #WIDTH,
-   │             ----- destination's requirement @[G+#W, G+#W+1]
+   │             ----- destination's requirement @[G+#W, G+(#W+1)]
    │
    = assignment violates constraint: N=0, W=1
 
-error: Cannot prove constraint G+#W+1 >= G+#N+1
+error: Cannot prove constraint G+(#W+1) >= G+(#N+1)
    ┌─ tests/errors/poly-mismatch.fil:13:11
    │
 13 │     out = a.out;
-   │     ---   ^^^^^ source is available for @[G+#W, G+#W+1]
+   │     ---   ^^^^^ source is available for @[G+#W, G+(#W+1)]
    │     │      
-   │     destination's requirement @[G+#N, G+#N+1]
+   │     destination's requirement @[G+#N, G+(#N+1)]
    │
    = assignment violates constraint: W=1, N=2
 
@@ -67,9 +67,9 @@ error: Cannot prove constraint G+#N >= G+#W
    ┌─ tests/errors/poly-mismatch.fil:13:11
    │
 13 │     out = a.out;
-   │     ---   ^^^^^ source is available for @[G+#W, G+#W+1]
+   │     ---   ^^^^^ source is available for @[G+#W, G+(#W+1)]
    │     │      
-   │     destination's requirement @[G+#N, G+#N+1]
+   │     destination's requirement @[G+#N, G+(#N+1)]
    │
    = assignment violates constraint: N=0, W=1
 

--- a/tests/errors/port-mismatch.expect
+++ b/tests/errors/port-mismatch.expect
@@ -1,12 +1,13 @@
 ---CODE---
 1
 ---STDERR---
-error: port width mismatch
+error: Cannot prove constraint 16 = 32
   ┌─ tests/errors/port-mismatch.fil:2:11
   │
 2 │     out = in;
   │     ---   ^^ source `in' has width 32
   │     │      
   │     destination `out' has width 16
+  │
 
 Compilation failed with 1 errors.

--- a/tests/errors/share-range.expect
+++ b/tests/errors/share-range.expect
@@ -1,16 +1,16 @@
 ---CODE---
 1
 ---STDERR---
-error: Cannot prove constraint 10 >= max(G+11) - min(G)
+error: Cannot prove constraint 10 >= max(G+2, G+11) - min(G, G+9)
    ┌─ tests/errors/share-range.fil:4:11
    │
  4 │ comp Main<G: 10>(
    │           ^^^^^ event's delay must be longer than the difference between minimum start time and maximum end time of all invocations
    ·
 13 │   m0 := M<G>(l0, r0);
-   │           - invocation starts at `G'
+   │           - invocation starts at `G' and ends at `G+2'
 14 │   m1 := M<G+9>(l1, r1);
-   │           - invocation ends at `G+11'
+   │           - invocation starts at `G+9' and ends at `G+11'
    │
    = assignment violates constraint: G=0
 

--- a/tests/errors/unbound-params.expect
+++ b/tests/errors/unbound-params.expect
@@ -55,13 +55,4 @@ error: undefined parameter name: N
 8 │     a := new Add[#W, #J]<L+#N>(a);
   │                            ^^ parameter is not defined in the signature
 
-error: port width mismatch
-  ┌─ tests/errors/unbound-params.fil:8:32
-  │
-2 │     @[G, G+#W] a: #W,
-  │                - destination `a' has width #W
-  ·
-8 │     a := new Add[#W, #J]<L+#N>(a);
-  │                                ^ source `a' has width #P
-
-Compilation failed with 10 errors.
+Compilation failed with 9 errors.

--- a/tests/errors/unprovable-cons.expect
+++ b/tests/errors/unprovable-cons.expect
@@ -13,7 +13,7 @@ error: Cannot prove constraint L+1 > G+1
    │   ---------------------- component's where clause constraints must be satisfied
    │
 
-error: Cannot prove constraint |L - G| >= 1
+error: Cannot prove constraint |L+1 - G+1| >= 1
    ┌─ ./primitives/./state.fil:7:5
    │
  3 │   comp Register[#WIDTH]<G: L-(G+1), L: 1>(


### PR DESCRIPTION
Allows using generic binary expressions. The big coup de grace is doing area-throughput trade-offs with the iterative divider implementation