### PR TITLE
Pin calyx crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ topological-sort = "0.2"
 atty = "0.2"
 lazy_static = "1.4.0"
 
-calyx-ir = { path = "../calyx/calyx-ir" }
-calyx-frontend = { path = "../calyx/calyx-frontend" }
-calyx-utils = { path = "../calyx/calyx-utils" }
+calyx-ir = { version = "0.1.1" }
+calyx-frontend = { version = "0.1.1" }
+calyx-utils = { version = "0.1.1" }
 
 [dependencies.env_logger]
 version = "0.9"

--- a/doc/docs/start.md
+++ b/doc/docs/start.md
@@ -9,7 +9,6 @@ Filament is a programming language for Fearless Hardware Design. It aims to enab
 The following commands are sufficient to build the Filament compiler and have it generate [Calyx IR](https://calyxir.org). First, we need to configure the Calyx compiler which acts as the backend for Filament.
 - Clone the [Calyx repository][calyx-repo]: `git clone https://github.com/cucapra/calyx.git` and build the `Calyx` compiler `cd calyx && cargo build`
 - Clone this repository: `git clone https://github.com/cucapra/filament.git`
-- Both repositories **must** be contained in the same parent folder such that they are sibling folders.
 
 Next, we can install the dependencies for the Filament compiler:
 - [Install Rust][install-rust] which will configure the `cargo` tool.

--- a/doc/docs/start.md
+++ b/doc/docs/start.md
@@ -56,7 +56,7 @@ runt -j 1
 Now that we have installed the Filament compiler and accompanying tools, we can start using Filament. Use the following links to learn more about Filament:
 
 - Writing your [first Filament Program](./lang/tutorial.md).
-- Overview of the [Filament Language](./lang/index.md).
+- [How do I integrate black-box Verilog with Filament](./lang/external.md)?
 
 ## Debugging Cocotb Installation
 


### PR DESCRIPTION
Use versions Calyx crate from crates.io to avoid random breakage from mainline Calyx changing