### PR TITLE
fix: `sig` anchors in the example section

### DIFF
--- a/examples/tut-pipe-wrong-1.fil
+++ b/examples/tut-pipe-wrong-1.fil
@@ -3,12 +3,12 @@ import "primitives/sequential.fil";
 
 /// ANCHOR: sig
 comp main<G: 1>(
-/// ANCHOR_END: sig
     @interface[G] go: 1,
     @[G, G+3] op: 1,
     @[G, G+1] left: 32,
     @[G, G+1] right: 32,
 ) -> (@[G+2, G+3] out: 32)
+/// ANCHOR_END: sig
 {
     A := new Add[32];
     M := new Mult[32];

--- a/examples/tut-seq.fil
+++ b/examples/tut-seq.fil
@@ -3,12 +3,12 @@ import "primitives/sequential.fil";
 
 /// ANCHOR: sig
 comp main<G: 3>(
-/// ANCHOR_END: sig
     @interface[G] go: 1,
     @[G, G+3] op: 1,
     @[G, G+1] left: 32,
     @[G, G+1] right: 32,
 ) -> (@[G+2, G+3] out: 32)
+/// ANCHOR_END: sig
 {
     A := new Add[32];
     M := new Mult[32];

--- a/examples/tut-wrong-1.fil
+++ b/examples/tut-wrong-1.fil
@@ -1,14 +1,14 @@
 import "primitives/core.fil";
 import "primitives/sequential.fil";
 
-/// ANCHOR: signature
+/// ANCHOR: sig
 comp main<G: 3>(
     @interface[G] go: 1,
     @[G, G+1] op: 1,
     @[G, G+1] left: 32,
     @[G, G+1] right: 32,
 ) -> (@[G, G+1] out: 32)
-// ANCHOR_END: signature
+/// ANCHOR_END: sig
 {
     A := new Add[32];
     M := new Mult[32];


### PR DESCRIPTION
Not sure if this was intended but some anchors were annotating the name of the function without the parameters as a sig, and some took all of the signature inside a sig anchor. So I made it consistent, and fixed a missing `/`.