### PR TITLE
Add checked `assert` statement

### DIFF
--- a/primitives/reshape.fil
+++ b/primitives/reshape.fil
@@ -32,7 +32,7 @@ comp GenSerialize[#W, #N, #B, #C, #H]<G: #C*(#N-1)+#H>(
 ) where #N > 0, #B > 0, #C > 0, #H > 0 {
     for #i in 0..#N {
         for #j in 0..#B {
-            assume (#B*#i+#j)/#B == #i;
+            assert (#B*#i+#j)/#B == #i; // Proof hint. Make type checking faster.
             if #i > 0 {
                 d := new Register[#W]<G, G+#C*#i+#H>(in{#B*#i+#j});
                 out{#B*#i+#j} = d.out;
@@ -88,7 +88,7 @@ comp GenDeserialize[#W, #N, #B, #C, #H]<G: #C*#N+#H-2>(
     for #i in 0..#N {
         // Accepts #B inputs this cycle and delay them
         for #j in 0..#B {
-            assume (#B*#i+#j)/#B == #i;
+            assert (#B*#i+#j)/#B == #i; // Proof hint. Make type checking faster.
             if #i < #N-1 {
                 d := new Register[#W]<G+#C*#i, G+#C*#N+#H-1>(in{#B*#i+#j});
                 out{#B*#i+#j} = d.out;

--- a/src/backend/compile.rs
+++ b/src/backend/compile.rs
@@ -418,7 +418,7 @@ fn compile_component(
             core::Command::If(_) => {
                 unreachable!("If should have been compiled away.")
             }
-            core::Command::Assume(a) => {
+            core::Command::Fact(a) => {
                 unreachable!("Assumption `{a}' should have been compiled away.")
             }
         };

--- a/src/binding/comp.rs
+++ b/src/binding/comp.rs
@@ -192,7 +192,7 @@ impl BoundComponent {
                 }
                 core::Command::Connect(_)
                 | core::Command::Fsm(_)
-                | core::Command::Assume(_) => (),
+                | core::Command::Fact(_) => (),
             }
         }
     }
@@ -330,7 +330,7 @@ impl BoundComponent {
                 core::Command::Bundle(bl) => {
                     self.add_bundle(bl.clone());
                 }
-                core::Command::Fsm(_) | core::Command::Assume(_) => (),
+                core::Command::Fsm(_) | core::Command::Fact(_) => (),
             }
         }
     }

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -43,7 +43,7 @@ impl Component {
                 }
                 Command::Instance(_)
                 | Command::Connect(_)
-                | Command::Assume(_)
+                | Command::Fact(_)
                 | Command::Bundle(_)
                 | Command::If(_)
                 | Command::ForLoop(_) => (),

--- a/src/core/control.rs
+++ b/src/core/control.rs
@@ -308,16 +308,18 @@ impl Display for Invoke {
 }
 
 #[derive(Clone)]
-/// An assumption in the component.
-/// Assumed to be true during type checking and validated during code
-/// generation.
+/// An `assert` or `assume` statement.
+/// If `checked` is true, the statement is checked to be statically true.
+/// Otherwise, it is assumed to be true.
 pub struct Fact {
     pub cons: Loc<OrderConstraint<Expr>>,
+    // If this fact is statically checked.
+    pub checked: bool,
 }
 
 impl Fact {
-    pub fn new(cons: Loc<OrderConstraint<Expr>>) -> Self {
-        Fact { cons }
+    pub fn new(cons: Loc<OrderConstraint<Expr>>, checked: bool) -> Self {
+        Fact { cons, checked }
     }
 
     pub fn exprs(&self) -> [&Expr; 2] {
@@ -337,6 +339,7 @@ impl Fact {
                 right: c.right.resolve(bind),
                 ..c
             }),
+            ..self
         }
     }
 

--- a/src/core/control.rs
+++ b/src/core/control.rs
@@ -153,7 +153,7 @@ impl std::fmt::Display for Port {
 pub enum Command {
     Invoke(Invoke),
     Instance(Instance),
-    Assume(Assume),
+    Fact(Fact),
     Connect(Connect),
     Fsm(Fsm),
     ForLoop(ForLoop),
@@ -186,9 +186,9 @@ impl From<Bundle> for Command {
         Self::Bundle(v)
     }
 }
-impl From<Assume> for Command {
-    fn from(v: Assume) -> Self {
-        Self::Assume(v)
+impl From<Fact> for Command {
+    fn from(v: Fact) -> Self {
+        Self::Fact(v)
     }
 }
 
@@ -202,7 +202,7 @@ impl Display for Command {
             Command::ForLoop(l) => write!(f, "{}", l),
             Command::If(l) => write!(f, "{}", l),
             Command::Bundle(b) => write!(f, "{b}"),
-            Command::Assume(a) => write!(f, "{a}"),
+            Command::Fact(a) => write!(f, "{a}"),
         }
     }
 }
@@ -311,13 +311,13 @@ impl Display for Invoke {
 /// An assumption in the component.
 /// Assumed to be true during type checking and validated during code
 /// generation.
-pub struct Assume {
+pub struct Fact {
     pub cons: Loc<OrderConstraint<Expr>>,
 }
 
-impl Assume {
+impl Fact {
     pub fn new(cons: Loc<OrderConstraint<Expr>>) -> Self {
-        Assume { cons }
+        Fact { cons }
     }
 
     pub fn exprs(&self) -> [&Expr; 2] {
@@ -331,7 +331,7 @@ impl Assume {
 
     /// Resolve expression in the assumption
     pub fn resolve(self, bind: &Binding<Expr>) -> Self {
-        Assume {
+        Fact {
             cons: self.cons.map(|c| OrderConstraint {
                 left: c.left.resolve(bind),
                 right: c.right.resolve(bind),
@@ -346,7 +346,7 @@ impl Assume {
     }
 }
 
-impl std::fmt::Display for Assume {
+impl std::fmt::Display for Fact {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "assume {}", self.cons)
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,7 +12,7 @@ mod time;
 pub use component::{Component, Namespace};
 pub use constraint::{Constraint, OrderConstraint, OrderOp};
 pub use control::{
-    Access, Assume, Bundle, BundleType, Command, Connect, ForLoop, Fsm, Guard,
+    Access, Bundle, BundleType, Command, Connect, Fact, ForLoop, Fsm, Guard,
     If, Instance, Invoke, Port,
 };
 pub use expr::{Expr, Op, UnFn};

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -665,10 +665,19 @@ impl FilamentParser {
         ))
     }
 
-    fn assume(input: Node) -> ParseResult<core::Fact> {
+    fn assume_w(input: Node) -> ParseResult<()> {
+        Ok(())
+    }
+    fn assert_w(input: Node) -> ParseResult<()> {
+        Ok(())
+    }
+
+    fn fact(input: Node) -> ParseResult<core::Fact> {
+        let sp = Self::get_span(&input);
         Ok(match_nodes!(
             input.into_children();
-            [expr_cmp(e)] => core::Fact::new(e.into(), false),
+            [assume_w(_), expr_cmp(e)] => core::Fact::new(Loc::new(e, sp), false),
+            [assert_w(_), expr_cmp(e)] => core::Fact::new(Loc::new(e, sp), true),
         ))
     }
 
@@ -682,7 +691,7 @@ impl FilamentParser {
             [for_loop(l)] => vec![core::Command::ForLoop(l)],
             [bundle(bl)] => vec![bl.into()],
             [if_stmt(if_)] => vec![if_.into()],
-            [assume(a)] => vec![a.into()]
+            [fact(a)] => vec![a.into()]
         ))
     }
 

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -665,10 +665,10 @@ impl FilamentParser {
         ))
     }
 
-    fn assume(input: Node) -> ParseResult<core::Assume> {
+    fn assume(input: Node) -> ParseResult<core::Fact> {
         Ok(match_nodes!(
             input.into_children();
-            [expr_cmp(e)] => core::Assume::new(e.into()),
+            [expr_cmp(e)] => core::Fact::new(e.into()),
         ))
     }
 

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -668,7 +668,7 @@ impl FilamentParser {
     fn assume(input: Node) -> ParseResult<core::Fact> {
         Ok(match_nodes!(
             input.into_children();
-            [expr_cmp(e)] => core::Fact::new(e.into()),
+            [expr_cmp(e)] => core::Fact::new(e.into(), false),
         ))
     }
 

--- a/src/frontend/syntax.pest
+++ b/src/frontend/syntax.pest
@@ -209,13 +209,15 @@ bundle = {
   "bundle" ~ identifier ~ "[" ~ expr ~ "]" ~ ":" ~ bundle_typ ~ ";"
 }
 
-assume = {
-  "assume" ~ expr_cmp ~ ";"
+assume_w = { "assume" }
+assert_w = { "assert" }
+fact = {
+  (assume_w | assert_w) ~ expr_cmp ~ ";"
 }
 
 // ========== Commands ==========
 command = {
-  bundle | instance | invocation | connect | fsm | for_loop | if_stmt | assume
+  bundle | instance | invocation | connect | fsm | for_loop | if_stmt | fact
 }
 
 commands = { command* }

--- a/src/passes/bind_check.rs
+++ b/src/passes/bind_check.rs
@@ -94,7 +94,7 @@ impl visitor::Checker for BindCheck {
         &mut self.diag
     }
 
-    fn assume(
+    fn fact(
         &mut self,
         a: &core::Fact,
         _ctx: &binding::CompBinding,

--- a/src/passes/bind_check.rs
+++ b/src/passes/bind_check.rs
@@ -96,7 +96,7 @@ impl visitor::Checker for BindCheck {
 
     fn assume(
         &mut self,
-        a: &core::Assume,
+        a: &core::Fact,
         _ctx: &binding::CompBinding,
     ) -> Traverse {
         for e in a.exprs() {

--- a/src/passes/bundle_elim.rs
+++ b/src/passes/bundle_elim.rs
@@ -300,7 +300,7 @@ impl BundleElim {
                 }
                 c @ (core::Command::Fsm(_)
                 | core::Command::Bundle(_)
-                | core::Command::Assume(_)) => {
+                | core::Command::Fact(_)) => {
                     vec![c]
                 }
             })

--- a/src/passes/interval_checking/checker.rs
+++ b/src/passes/interval_checking/checker.rs
@@ -328,7 +328,7 @@ impl visitor::Checker for IntervalCheck {
         &mut self.diag
     }
 
-    fn assume(&mut self, a: &core::Assume, _: &CompBinding) -> Traverse {
+    fn assume(&mut self, a: &core::Fact, _: &CompBinding) -> Traverse {
         self.push_path_cond(a.clone().constraint());
         Traverse::Continue(())
     }

--- a/src/passes/interval_checking/checker.rs
+++ b/src/passes/interval_checking/checker.rs
@@ -328,7 +328,18 @@ impl visitor::Checker for IntervalCheck {
         &mut self.diag
     }
 
-    fn assume(&mut self, a: &core::Fact, _: &CompBinding) -> Traverse {
+    fn fact(&mut self, a: &core::Fact, _: &CompBinding) -> Traverse {
+        if a.checked {
+            let obl = a
+                .cons
+                .inner()
+                .clone()
+                .obligation("assertion is false")
+                .add_note(
+                    self.diag.add_info("assertion is false", a.cons.pos()),
+                );
+            self.add_obligations(Some(obl))
+        }
         self.push_path_cond(a.clone().constraint());
         Traverse::Continue(())
     }

--- a/src/passes/monomorphize/mono.rs
+++ b/src/passes/monomorphize/mono.rs
@@ -115,7 +115,7 @@ impl<'e> Monomorphize<'e> {
         let mut n_cmds = Vec::new();
         for cmd in commands {
             match cmd {
-                core::Command::Assume(core::Assume { cons }) => {
+                core::Command::Fact(core::Fact { cons }) => {
                     match cons.clone().take().eval(param_binding) {
                         Ok(true) => (),
                         Ok(false) => {

--- a/src/passes/monomorphize/mono.rs
+++ b/src/passes/monomorphize/mono.rs
@@ -115,11 +115,11 @@ impl<'e> Monomorphize<'e> {
         let mut n_cmds = Vec::new();
         for cmd in commands {
             match cmd {
-                core::Command::Fact(core::Fact { cons }) => {
+                core::Command::Fact(core::Fact { cons, .. }) => {
                     match cons.clone().take().eval(param_binding) {
                         Ok(true) => (),
                         Ok(false) => {
-                            panic!("Assumption violated during elaboration.")
+                            panic!("Assumption `{}' violated during elaboration. Bindings: {:?}", cons.inner(), param_binding)
                         }
                         Err(e) => {
                             panic!(

--- a/src/passes/monomorphize/rewriter.rs
+++ b/src/passes/monomorphize/rewriter.rs
@@ -70,7 +70,7 @@ impl Rewriter {
                         "If statements should be monomorphized already"
                     )
                 }
-                core::Command::Connect(_) | core::Command::Assume(_) => {}
+                core::Command::Connect(_) | core::Command::Fact(_) => {}
             }
         }
         let mut n_cmds = Vec::with_capacity(cmds.len());
@@ -132,7 +132,7 @@ impl Rewriter {
                 }
                 core::Command::If(_)
                 | core::Command::ForLoop(_)
-                | core::Command::Assume(_)
+                | core::Command::Fact(_)
                 | core::Command::Fsm(_) => unreachable!(),
             };
             n_cmds.push(out);

--- a/src/utils/post_order.rs
+++ b/src/utils/post_order.rs
@@ -78,7 +78,7 @@ fn process_cmd(
         core::Command::Connect(_)
         | core::Command::Invoke(_)
         | core::Command::Bundle(_)
-        | core::Command::Assume(_)
+        | core::Command::Fact(_)
         | core::Command::Fsm(_) => (),
     }
 }

--- a/src/visitor/checker.rs
+++ b/src/visitor/checker.rs
@@ -101,13 +101,13 @@ where
     }
 
     #[inline]
-    fn assume(&mut self, _: &core::Assume, _ctx: &CompBinding) -> Traverse {
+    fn assume(&mut self, _: &core::Fact, _ctx: &CompBinding) -> Traverse {
         Traverse::Continue(())
     }
 
     fn command(&mut self, cmd: &core::Command, ctx: &CompBinding) -> Traverse {
         match cmd {
-            core::Command::Assume(a) => self.assume(a, ctx),
+            core::Command::Fact(a) => self.assume(a, ctx),
             core::Command::Bundle(bl) => self.bundle(false, bl, ctx),
             core::Command::Invoke(inv) => self.invoke(inv, ctx),
             core::Command::Instance(inst) => self.instance(inst, ctx),

--- a/src/visitor/checker.rs
+++ b/src/visitor/checker.rs
@@ -101,13 +101,13 @@ where
     }
 
     #[inline]
-    fn assume(&mut self, _: &core::Fact, _ctx: &CompBinding) -> Traverse {
+    fn fact(&mut self, _: &core::Fact, _ctx: &CompBinding) -> Traverse {
         Traverse::Continue(())
     }
 
     fn command(&mut self, cmd: &core::Command, ctx: &CompBinding) -> Traverse {
         match cmd {
-            core::Command::Fact(a) => self.assume(a, ctx),
+            core::Command::Fact(a) => self.fact(a, ctx),
             core::Command::Bundle(bl) => self.bundle(false, bl, ctx),
             core::Command::Invoke(inv) => self.invoke(inv, ctx),
             core::Command::Instance(inst) => self.instance(inst, ctx),

--- a/src/visitor/visit.rs
+++ b/src/visitor/visit.rs
@@ -143,7 +143,7 @@ where
                     core::Command::Connect(con) => pass.connect(con, &ctx)?,
                     core::Command::Fsm(fsm) => pass.fsm(fsm, &ctx)?,
                     core::Command::Bundle(bl) => pass.bundle(bl, &ctx)?,
-                    core::Command::Assume(_) => unreachable!(
+                    core::Command::Fact(_) => unreachable!(
                         "Visitor does not support transforming assumptions"
                     ),
                     core::Command::ForLoop(_) => unreachable!(

--- a/tools/vscode/syntaxes/filament.tmLanguage.json
+++ b/tools/vscode/syntaxes/filament.tmLanguage.json
@@ -60,7 +60,7 @@
 				},
 				{
 					"name": "keyword.control.filament",
-					"match": "\\b(where|for|if|else|assume)\\b"
+					"match": "\\b(where|for|if|else|assume|assert)\\b"
 				}
 			]
 		},


### PR DESCRIPTION
Unlike an `assume`, an `assert` is statically checked by the compiler. They are mostly useful as proof hints to make the type checking be faster for complex components.