### PR TITLE
Simplify AST a bit

### DIFF
--- a/src/ast/control.rs
+++ b/src/ast/control.rs
@@ -158,16 +158,9 @@ pub enum Command {
     Instance(Instance),
     Fact(Fact),
     Connect(Connect),
-    Fsm(Fsm),
     ForLoop(ForLoop),
     If(If),
     Bundle(Bundle),
-}
-
-impl From<Fsm> for Command {
-    fn from(v: Fsm) -> Self {
-        Self::Fsm(v)
-    }
 }
 
 impl From<Connect> for Command {
@@ -205,7 +198,6 @@ impl Display for Command {
             Command::Invoke(inv) => write!(f, "{}", inv),
             Command::Instance(ins) => write!(f, "{}", ins),
             Command::Connect(con) => write!(f, "{}", con),
-            Command::Fsm(fsm) => write!(f, "{}", fsm),
             Command::ForLoop(l) => write!(f, "{}", l),
             Command::If(l) => write!(f, "{}", l),
             Command::Bundle(b) => write!(f, "{b}"),

--- a/src/binding/comp.rs
+++ b/src/binding/comp.rs
@@ -190,9 +190,7 @@ impl BoundComponent {
                     self.process_cmds(prog, &if_.then);
                     self.process_cmds(prog, &if_.alt);
                 }
-                ast::Command::Connect(_)
-                | ast::Command::Fsm(_)
-                | ast::Command::Fact(_) => (),
+                ast::Command::Connect(_) | ast::Command::Fact(_) => (),
             }
         }
     }
@@ -330,7 +328,7 @@ impl BoundComponent {
                 ast::Command::Bundle(bl) => {
                     self.add_bundle(bl.clone());
                 }
-                ast::Command::Fsm(_) | ast::Command::Fact(_) => (),
+                ast::Command::Fact(_) => (),
             }
         }
     }

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -606,13 +606,6 @@ impl FilamentParser {
         ))
     }
 
-    fn fsm(input: Node) -> ParseResult<ast::Fsm> {
-        Ok(match_nodes!(
-            input.into_children();
-            [identifier(name), bitwidth(states), port(trigger)] => ast::Fsm::new(name.take(), states, trigger.take()),
-        ))
-    }
-
     fn expr_cmp(input: Node) -> ParseResult<ast::OrderConstraint<ast::Expr>> {
         Ok(match_nodes!(
             input.into_children();
@@ -690,7 +683,6 @@ impl FilamentParser {
             [invocation(assign)] => vec![ast::Command::Invoke(assign)],
             [instance(cmd)] => cmd,
             [connect(con)] => vec![ast::Command::Connect(con)],
-            [fsm(fsm)] => vec![ast::Command::Fsm(fsm)],
             [for_loop(l)] => vec![ast::Command::ForLoop(l)],
             [bundle(bl)] => vec![bl.into()],
             [if_stmt(if_)] => vec![if_.into()],

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -439,12 +439,7 @@ impl FilamentParser {
                 identifier(bind),
                 identifier(comp),
                 invoke_args((abstract_vars, ports))
-            ] => ast::Invoke::new(bind, comp, abstract_vars, Some(ports)),
-            [
-                identifier(bind),
-                identifier(comp),
-                time_args(abstract_vars),
-            ] => ast::Invoke::new(bind, comp, abstract_vars, None),
+            ] => ast::Invoke::new(bind, comp, abstract_vars, Some(ports))
         ))
     }
     fn gte(input: Node) -> ParseResult<()> {

--- a/src/frontend/syntax.pest
+++ b/src/frontend/syntax.pest
@@ -182,10 +182,6 @@ invocation = {
   | identifier ~ ":=" ~ "invoke" ~ identifier ~ time_args ~ ";"
 }
 
-fsm = {
-  "fsm" ~ identifier ~ "[" ~ bitwidth ~ "]" ~ "(" ~ port ~ ")" ~ ";"
-}
-
 // ===== if statements ====
 expr_cmp = {
   expr ~ order_op ~ expr
@@ -223,7 +219,7 @@ fact = {
 
 // ========== Commands ==========
 command = {
-  bundle | instance | invocation | connect | fsm | for_loop | if_stmt | fact
+  bundle | instance | invocation | connect | for_loop | if_stmt | fact
 }
 
 commands = { command* }

--- a/src/frontend/syntax.pest
+++ b/src/frontend/syntax.pest
@@ -179,7 +179,6 @@ invoke_args = {
 
 invocation = {
   identifier ~ ":=" ~ identifier ~ invoke_args ~ ";"
-  | identifier ~ ":=" ~ "invoke" ~ identifier ~ time_args ~ ";"
 }
 
 // ===== if statements ====

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn run(opts: &cmdline::Opts) -> Result<(), u64> {
     let states = passes::MaxStates::check(opts, &ns, &bind)?;
 
     if opts.dump_interface {
-        passes::DumpInterface::transform_unwrap(ns, states.max_states);
+        passes::DumpInterface::print(&ns, &states.max_states);
         return Ok(());
     }
 

--- a/src/passes/bundle_elim.rs
+++ b/src/passes/bundle_elim.rs
@@ -299,9 +299,7 @@ impl BundleElim {
                     let alt = self.commands(alt);
                     vec![ast::If { cond, then, alt }.into()]
                 }
-                c @ (ast::Command::Fsm(_)
-                | ast::Command::Bundle(_)
-                | ast::Command::Fact(_)) => {
+                c @ (ast::Command::Bundle(_) | ast::Command::Fact(_)) => {
                     vec![c]
                 }
             })
@@ -317,6 +315,7 @@ impl BundleElim {
         ast::Component {
             sig,
             body: pre_cmds,
+            ..comp
         }
     }
 }

--- a/src/passes/monomorphize/mono.rs
+++ b/src/passes/monomorphize/mono.rs
@@ -266,9 +266,6 @@ impl<'e> Monomorphize<'e> {
                         n_cmds.extend(rw.rewrite(ncmds));
                     }
                 }
-                ast::Command::Fsm(_) => {
-                    unreachable!("FSMs cannot be monomorphized")
-                }
             }
         }
         n_cmds
@@ -294,7 +291,9 @@ impl<'e> Monomorphize<'e> {
         );
         let body =
             self.commands(comp.body.iter().cloned(), binding, prev_names, "");
-        ast::Component { sig, body }
+
+        assert!(comp.fsms.is_empty(), "Component should not have FSMs");
+        ast::Component::new(sig, body)
     }
 }
 

--- a/src/passes/monomorphize/rewriter.rs
+++ b/src/passes/monomorphize/rewriter.rs
@@ -59,9 +59,6 @@ impl Rewriter {
                     self.add_name(*inst.name.inner())
                 }
                 ast::Command::Bundle(bl) => self.add_name(*bl.name.inner()),
-                ast::Command::Fsm(_) => {
-                    unreachable!("Cannot monomorphize FSMs")
-                }
                 ast::Command::ForLoop(_) => {
                     unreachable!("Inner loops should be monomorphized already")
                 }
@@ -129,8 +126,7 @@ impl Rewriter {
                 }
                 ast::Command::If(_)
                 | ast::Command::ForLoop(_)
-                | ast::Command::Fact(_)
-                | ast::Command::Fsm(_) => unreachable!(),
+                | ast::Command::Fact(_) => unreachable!(),
             };
             n_cmds.push(out);
         }

--- a/src/utils/post_order.rs
+++ b/src/utils/post_order.rs
@@ -78,8 +78,7 @@ fn process_cmd(
         ast::Command::Connect(_)
         | ast::Command::Invoke(_)
         | ast::Command::Bundle(_)
-        | ast::Command::Fact(_)
-        | ast::Command::Fsm(_) => (),
+        | ast::Command::Fact(_) => (),
     }
 }
 

--- a/src/visitor/checker.rs
+++ b/src/visitor/checker.rs
@@ -30,11 +30,6 @@ where
     }
 
     #[inline]
-    fn fsm(&mut self, _: &ast::Fsm, _ctx: &CompBinding) -> Traverse {
-        Traverse::Continue(())
-    }
-
-    #[inline]
     fn forloop(&mut self, l: &ast::ForLoop, ctx: &CompBinding) -> Traverse {
         for cmd in &l.body {
             self.command(cmd, ctx)?;
@@ -112,7 +107,6 @@ where
             ast::Command::Invoke(inv) => self.invoke(inv, ctx),
             ast::Command::Instance(inst) => self.instance(inst, ctx),
             ast::Command::Connect(con) => self.connect(con, ctx),
-            ast::Command::Fsm(fsm) => self.fsm(fsm, ctx),
             ast::Command::ForLoop(l) => self.forloop(l, ctx),
             ast::Command::If(i) => self.if_(i, ctx),
         }

--- a/tests/errors/invoke-trig-too-often.expect
+++ b/tests/errors/invoke-trig-too-often.expect
@@ -2,7 +2,7 @@
 1
 ---STDERR---
 error: event provided to invocation triggers more often that invocation's event's delay allows
-  ┌─ tests/errors/invoke-trig-too-often.fil:9:18
+  ┌─ tests/errors/invoke-trig-too-often.fil:9:11
   │
 2 │   comp Mult<G: 5>(
   │                - invocation's event is allowed to trigger every 5 cycles
@@ -10,8 +10,8 @@ error: event provided to invocation triggers more often that invocation's event'
 7 │ comp Main<T: 3>(@interface[T] go_T: 1) -> () {
   │              - this event triggers every 3 cycles
 8 │   M := new Mult;
-9 │   m0 := invoke M<T+1>;
-  │                  ^^^ event provided to invoke triggers too often
+9 │   m0 := M<T+1>();
+  │           ^^^ event provided to invoke triggers too often
 
 Compilation failed with 1 errors.
 Run with --show-models to generate assignments for failing constraints.

--- a/tests/errors/invoke-trig-too-often.fil
+++ b/tests/errors/invoke-trig-too-often.fil
@@ -6,5 +6,5 @@ extern "dummy.sv" {
 
 comp Main<T: 3>(@interface[T] go_T: 1) -> () {
   M := new Mult;
-  m0 := invoke M<T+1>;
+  m0 := M<T+1>();
 }


### PR DESCRIPTION
Don't parse `fsm` and `invoke` constructs (these are now considered virtual constructs and only used internally for compilation) and make FSMs a field on components instead of a command.