### PR TITLE
Print assignments demonstrating false `assert`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ smallvec = "1"
 topological-sort = "0.2"
 atty = "0.2"
 lazy_static = "1.4.0"
-easy-smt = { git = "https://github.com/rachitnigam/easy-smt" }
+easy-smt = "0.1.2"
 
 calyx-ir = { version = "=0.2.0" }
 calyx-frontend = { version = "=0.2.0" }

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -421,6 +421,7 @@ enum ECtx {
     Add,
     /// Inside an multiplication priority expression (* or / or %)
     Mul,
+    #[allow(dead_code)]
     /// Inside a function application
     Func,
 }

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -1,7 +1,7 @@
 use super::{
     CmpOp, Command, CompIdx, Ctx, Event, EventIdx, Expr, ExprIdx, Fact,
-    IndexStore, InstIdx, Instance, Interned, InvIdx, Invoke, Param, ParamIdx,
-    Port, PortIdx, Prop, PropIdx, Time, TimeIdx, TimeSub,
+    IndexStore, Info, InfoIdx, InstIdx, Instance, Interned, InvIdx, Invoke,
+    Param, ParamIdx, Port, PortIdx, Prop, PropIdx, Time, TimeIdx, TimeSub,
 };
 use crate::{ast, utils::Idx};
 use itertools::Itertools;
@@ -42,10 +42,14 @@ pub struct Component {
     /// Events defined by the component
     pub events: IndexStore<Event>,
 
+    // Control flow entities
     /// Instances defined by the component
     pub instances: IndexStore<Instance>,
     /// Invocations defined by the component
     pub invocations: IndexStore<Invoke>,
+
+    /// Information tracked by the component
+    pub info: IndexStore<Info>,
 
     // Interned data. We store this on a per-component basis because events with the
     // same identifiers in different components are not equal.
@@ -69,6 +73,7 @@ impl Component {
             events: IndexStore::default(),
             instances: IndexStore::default(),
             invocations: IndexStore::default(),
+            info: IndexStore::default(),
             exprs: Interned::default(),
             times: Interned::default(),
             props: Interned::default(),
@@ -377,6 +382,16 @@ impl Ctx<Prop> for Component {
 
     fn get(&self, idx: Idx<Prop>) -> &Prop {
         self.props.get(idx)
+    }
+}
+
+impl Ctx<Info> for Component {
+    fn add(&mut self, val: Info) -> InfoIdx {
+        self.info.add(val)
+    }
+
+    fn get(&self, idx: InfoIdx) -> &Info {
+        self.info.get(idx)
     }
 }
 

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -94,20 +94,20 @@ impl Component {
 
     /// Generate a asserted fact.
     /// Panics if the asserted fact is false.
-    pub fn assert(&self, prop: PropIdx) -> Fact {
+    pub fn assert(&mut self, prop: PropIdx, info: InfoIdx) -> Fact {
         if prop.is_false(self) {
             panic!("Attempted to assert false");
         }
-        Fact::assert(prop)
+        Fact::assert(prop, info)
     }
 
     /// Generate an assumed fact.
     /// Panics if the assumed fact is false.
-    pub fn assume(&self, prop: PropIdx) -> Fact {
+    pub fn assume(&mut self, prop: PropIdx, info: InfoIdx) -> Fact {
         if prop.is_false(self) {
             panic!("Attempted to assume false");
         }
-        Fact::assume(prop)
+        Fact::assume(prop, info)
     }
 }
 

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -184,9 +184,16 @@ impl Component {
 
 /// Implement methods to display various values bound by the component
 impl Component {
+    pub fn display_param(&self, param: ParamIdx) -> String {
+        let Info::Param { name, .. } = self.get(self.get(param).info) else {
+            unreachable!("Expected param info");
+        };
+        format!("#{name}")
+    }
+
     fn display_expr_helper(&self, expr: ExprIdx, ctx: ECtx) -> String {
         match self.get(expr) {
-            Expr::Param(p) => format!("{p}"),
+            Expr::Param(p) => self.display_param(*p),
             Expr::Concrete(n) => format!("{n}"),
             Expr::Bin { op, lhs, rhs } => {
                 let inner = ECtx::from(*op);

--- a/src/ir/control.rs
+++ b/src/ir/control.rs
@@ -1,9 +1,8 @@
-use std::fmt;
-
 use super::{
-    Access, CompIdx, EventIdx, ExprIdx, Fact, InstIdx, InvIdx, ParamIdx,
-    PortIdx, PropIdx, TimeIdx,
+    Access, CompIdx, EventIdx, ExprIdx, Fact, InfoIdx, InstIdx, InvIdx,
+    ParamIdx, PortIdx, PropIdx, TimeIdx,
 };
+use std::fmt;
 
 #[derive(Clone, PartialEq, Eq)]
 /// A flattened and minimized representation of the control flow graph.
@@ -80,6 +79,7 @@ impl fmt::Display for Instance {
 pub struct Connect {
     pub src: Access,
     pub dst: Access,
+    pub info: InfoIdx,
 }
 impl fmt::Display for Connect {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/ir/fact.rs
+++ b/src/ir/fact.rs
@@ -112,6 +112,7 @@ impl fmt::Display for Prop {
     }
 }
 
+/// Constructors for propositions
 impl PropIdx {
     #[inline(always)]
     /// Returns true of this proposition is definitely true.
@@ -208,6 +209,18 @@ impl PropIdx {
         }
 
         ctx.add(Prop::Implies(self, cons))
+    }
+}
+
+/// Queries over propositions
+impl PropIdx {
+    /// Returns the consequent of an implication, if this proposition is an
+    /// implication. Otherwise, returns the proposition itself.
+    pub fn consequent(self, ctx: &impl Ctx<Prop>) -> PropIdx {
+        match ctx.get(self) {
+            Prop::Implies(_, cons) => *cons,
+            _ => self,
+        }
     }
 }
 

--- a/src/ir/fact.rs
+++ b/src/ir/fact.rs
@@ -1,6 +1,6 @@
 use super::{
-    idxs::PropIdx, Component, Ctx, ExprIdx, Foldable, ParamIdx, TimeIdx,
-    TimeSub,
+    idxs::PropIdx, Component, Ctx, ExprIdx, Foldable, InfoIdx, ParamIdx,
+    TimeIdx, TimeSub,
 };
 use std::fmt::{self, Display};
 
@@ -230,24 +230,26 @@ impl PropIdx {
 /// checked. Otherwise, it is an assumption.
 pub struct Fact {
     pub prop: PropIdx,
+    pub reason: InfoIdx,
     pub(super) checked: bool,
 }
 
 impl Fact {
     /// An assertion which is required to be statically proved
-    /// Outside the IR library, use [Component::assert] instead.
-    pub(super) fn assert(prop: PropIdx) -> Self {
+    pub fn assert(prop: PropIdx, reason: InfoIdx) -> Self {
         Self {
             prop,
+            reason,
             checked: true,
         }
     }
 
     /// An assumption which is not checked
     /// Outside the IR library, use [Component::assume] instead.
-    pub(super) fn assume(prop: PropIdx) -> Self {
+    pub(super) fn assume(prop: PropIdx, reason: InfoIdx) -> Self {
         Self {
             prop,
+            reason,
             checked: false,
         }
     }

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -113,8 +113,13 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
 
     /// Add an event to the component.
     fn event(&mut self, eb: ast::EventBind, owner: ir::EventOwner) -> EventIdx {
+        let info = self.comp.add(ir::Info::event(
+            eb.event.copy(),
+            eb.event.pos(),
+            eb.delay.pos(),
+        ));
         let delay = self.timesub(eb.delay.take());
-        let e = ir::Event { delay, owner };
+        let e = ir::Event { delay, owner, info };
         let idx = self.comp.add(e);
         self.event_map.insert(*eb.event, idx);
         idx

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -467,7 +467,9 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
         let mut connects = Vec::with_capacity(sig.inputs.len());
 
         for (p, src) in sig.inputs.clone().into_iter().zip(srcs) {
-            let info = self.comp.add(ir::Info::connect(p.pos(), src.pos()));
+            let info = self
+                .comp
+                .add(ir::Info::connect(p.inner().name().pos(), src.pos()));
             let resolved = p.map(|p| {
                 p.resolve_exprs(&param_binding)
                     .resolve_event(&event_binding)

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -138,10 +138,17 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
                 liveness,
                 bitwidth,
             } => {
-                let p_name = Id::from("__FAKE_BUNDLE_PARAM");
+                let info = self.comp.add(ir::Info::port(
+                    name.copy(),
+                    name.pos(),
+                    bitwidth.pos(),
+                    liveness.pos(),
+                ));
+
                 // The bundle type uses a fake bundle index and has a length of 1.
                 // We don't need to push a new scope because this type is does not
                 // bind any new parameters.
+                let p_name = Id::from("__FAKE_BUNDLE_PARAM");
                 let live = self.with_scope(|ctx| ir::Liveness {
                     idx: ctx.param(
                         p_name,
@@ -151,11 +158,11 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
                     len: ctx.comp.num(1),
                     range: ctx.range(liveness.take()),
                 });
-
                 let p = ir::Port {
                     width: self.expr(bitwidth.take()),
                     owner: owner.clone(),
                     live,
+                    info,
                 };
                 (name, p, owner)
             }
@@ -169,17 +176,23 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
                         bitwidth,
                     },
             }) => {
+                let info = self.comp.add(ir::Info::port(
+                    name.copy(),
+                    name.pos(),
+                    bitwidth.pos(),
+                    liveness.pos(),
+                ));
                 // Construct the bundle type in a new scope.
                 let live = self.with_scope(|ctx| ir::Liveness {
                     idx: ctx.param(*idx, ir::ParamOwner::Bundle, idx.pos()),
                     len: ctx.expr(len.take()),
                     range: ctx.range(liveness.take()),
                 });
-
                 let p = ir::Port {
                     width: self.expr(bitwidth.take()),
                     owner: owner.clone(),
                     live,
+                    info,
                 };
                 (name, p, owner)
             }

--- a/src/ir/from_ast/build_ctx.rs
+++ b/src/ir/from_ast/build_ctx.rs
@@ -18,8 +18,8 @@ pub struct Sig {
     pub events: Vec<ast::EventBind>,
     pub inputs: Vec<ast::Loc<ast::PortDef>>,
     pub outputs: Vec<ast::PortDef>,
-    pub param_cons: Vec<ast::OrderConstraint<ast::Expr>>,
-    pub event_cons: Vec<ast::OrderConstraint<ast::Time>>,
+    pub param_cons: Vec<ast::Loc<ast::OrderConstraint<ast::Expr>>>,
+    pub event_cons: Vec<ast::Loc<ast::OrderConstraint<ast::Time>>>,
 }
 
 impl From<(&ast::Signature, usize)> for Sig {
@@ -30,16 +30,8 @@ impl From<(&ast::Signature, usize)> for Sig {
             inputs: sig.inputs().cloned().collect_vec(),
             outputs: sig.outputs().map(|p| p.clone().take()).collect(),
             events: sig.events.iter().map(|e| e.clone().take()).collect(),
-            param_cons: sig
-                .param_constraints
-                .iter()
-                .map(|f| f.clone().take())
-                .collect(),
-            event_cons: sig
-                .event_constraints
-                .iter()
-                .map(|f| f.clone().take())
-                .collect(),
+            param_cons: sig.param_constraints.clone(),
+            event_cons: sig.event_constraints.clone(),
         }
     }
 }

--- a/src/ir/from_ast/build_ctx.rs
+++ b/src/ir/from_ast/build_ctx.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 use super::ScopeMap;
 use crate::ast::{self, Id};
 use crate::ir::{self, CompIdx, DenseIndexInfo, PortIdx};
@@ -14,7 +16,7 @@ pub struct Sig {
     pub idx: CompIdx,
     pub params: Vec<ast::Id>,
     pub events: Vec<ast::EventBind>,
-    pub inputs: Vec<ast::PortDef>,
+    pub inputs: Vec<ast::Loc<ast::PortDef>>,
     pub outputs: Vec<ast::PortDef>,
     pub param_cons: Vec<ast::OrderConstraint<ast::Expr>>,
     pub event_cons: Vec<ast::OrderConstraint<ast::Time>>,
@@ -25,7 +27,7 @@ impl From<(&ast::Signature, usize)> for Sig {
         Sig {
             idx: CompIdx::new(idx),
             params: sig.params.iter().map(|p| p.copy()).collect(),
-            inputs: sig.inputs().map(|p| p.clone().take()).collect(),
+            inputs: sig.inputs().cloned().collect_vec(),
             outputs: sig.outputs().map(|p| p.clone().take()).collect(),
             events: sig.events.iter().map(|e| e.clone().take()).collect(),
             param_cons: sig

--- a/src/ir/idxs.rs
+++ b/src/ir/idxs.rs
@@ -1,6 +1,6 @@
 use super::{
-    Command, CompOrExt, Ctx, Event, Expr, Instance, Invoke, Param, Port, Prop,
-    Time,
+    Command, CompOrExt, Ctx, Event, Expr, Info, Instance, Invoke, Param, Port,
+    Prop, Time,
 };
 use crate::define_idx;
 
@@ -31,6 +31,7 @@ impl PortIdx {
 }
 
 define_idx!(PropIdx, Prop, "prop");
+define_idx!(InfoIdx, Info, "info");
 
 define_idx!(CmdIdx, Command, "cmd");
 define_idx!(InstIdx, Instance, "inst");

--- a/src/ir/info.rs
+++ b/src/ir/info.rs
@@ -1,0 +1,103 @@
+use super::Range;
+use crate::{ast, utils::GPosIdx};
+
+#[derive(Default)]
+/// Information associated with the IR.
+pub enum Info {
+    #[default]
+    /// An absence of information is still information
+    Empty,
+    /// Assertion information
+    Assert(AssertReason),
+    /// Parameter information
+    Param {
+        /// Surface-level name of the parameter
+        name: ast::Id,
+        bind_loc: GPosIdx,
+    },
+    /// Event Information
+    Event {
+        /// Surface-level name of the event
+        name: ast::Id,
+        bind_loc: GPosIdx,
+        delay_loc: GPosIdx,
+    },
+    /// Information for an instance
+    Instance {
+        name_loc: GPosIdx,
+        comp_loc: GPosIdx,
+        bind_loc: GPosIdx,
+    },
+    /// Information for an invocation
+    Invoke {
+        name_loc: GPosIdx,
+        inst_loc: GPosIdx,
+        bind_loc: GPosIdx,
+    },
+    /// Information for Connection
+    Connect { dst_loc: GPosIdx, src_loc: GPosIdx },
+}
+
+impl Info {
+    /// Construct information about a parameter
+    pub fn param(name: ast::Id, bind_loc: GPosIdx) -> Self {
+        Self::Param { name, bind_loc }
+    }
+
+    /// Construct information about an event
+    pub fn event(name: ast::Id, bind_loc: GPosIdx, delay_loc: GPosIdx) -> Self {
+        Self::Event {
+            name,
+            bind_loc,
+            delay_loc,
+        }
+    }
+
+    /// Construct information about an instance
+    pub fn instance(
+        name_loc: GPosIdx,
+        comp_loc: GPosIdx,
+        bind_loc: GPosIdx,
+    ) -> Self {
+        Self::Instance {
+            name_loc,
+            comp_loc,
+            bind_loc,
+        }
+    }
+
+    /// Construct information about an invocation
+    pub fn connect(dst_loc: GPosIdx, src_loc: GPosIdx) -> Self {
+        Self::Connect { dst_loc, src_loc }
+    }
+}
+
+/// Why was an assertion created?
+pub enum AssertReason {
+    /// Assertion representing constraint on a parameter
+    ParamConstraint {
+        /// Location of parameter definition
+        param_def_loc: GPosIdx,
+        /// Location of the binding
+        bind_loc: GPosIdx,
+        /// Location of the constraint
+        constraint_loc: GPosIdx,
+    },
+    /// Assertion representing constraint on an event
+    EventConstraint {
+        /// Location of event definition
+        event_def_loc: GPosIdx,
+        /// Location of the binding
+        bind_loc: GPosIdx,
+        /// Location of the constraint
+        constraint_loc: GPosIdx,
+    },
+    /// Assertion requiring that the source is available for at least as long as
+    /// the destination requires
+    Liveness {
+        dst_loc: GPosIdx,
+        src_loc: GPosIdx,
+        dst_liveness: Range,
+        src_liveness: Range,
+    },
+}

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -20,7 +20,7 @@ pub use idxs::{
     CmdIdx, CompIdx, EventIdx, ExprIdx, InfoIdx, InstIdx, InvIdx, ParamIdx,
     PortIdx, PropIdx, TimeIdx,
 };
-pub use info::{AssertReason, Info};
+pub use info::{Info, Reason};
 pub use printer::Printer;
 pub use structure::{
     Access, Direction, Event, EventOwner, Liveness, Param, ParamOwner, Port,

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -4,6 +4,7 @@ mod expr;
 mod fact;
 mod from_ast;
 mod idxs;
+mod info;
 mod printer;
 mod structure;
 mod subst;
@@ -16,9 +17,10 @@ pub use expr::Expr;
 pub use fact::{Cmp, CmpOp, Fact, Prop};
 pub use from_ast::astconv::transform;
 pub use idxs::{
-    CmdIdx, CompIdx, EventIdx, ExprIdx, InstIdx, InvIdx, ParamIdx, PortIdx,
-    PropIdx, TimeIdx,
+    CmdIdx, CompIdx, EventIdx, ExprIdx, InfoIdx, InstIdx, InvIdx, ParamIdx,
+    PortIdx, PropIdx, TimeIdx,
 };
+pub use info::{AssertReason, Info};
 pub use printer::Printer;
 pub use structure::{
     Access, Direction, Event, EventOwner, Liveness, Param, ParamOwner, Port,

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -264,6 +264,7 @@ impl Printer {
             instances,
             invocations,
             cmds,
+            info: _,
         } = &c;
         Printer::sig(*idx, params, events, ports, 0, f)?;
         for (idx, param) in params.iter() {

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -1,3 +1,4 @@
+use super::Ctx;
 use crate::{ir, utils::Idx};
 use itertools::{Itertools, Position};
 use std::{fmt::Display, io};
@@ -185,10 +186,15 @@ impl Printer {
         idx: ir::ParamIdx,
         param: &ir::Param,
         indent: usize,
+        c: &ir::Component,
         f: &mut impl io::Write,
     ) -> io::Result<()> {
         if !param.is_sig_owned() {
-            writeln!(f, "{:indent$}{idx} = param {param};", "",)?;
+            let &ir::Param { info, .. } = c.get(idx);
+            let ir::Info::Param { name, .. } = c.get(info) else {
+                unreachable!("Expected param info");
+            };
+            writeln!(f, "{:indent$}{idx} = param {param}; // {name}", "",)?;
         }
         Ok(())
     }
@@ -270,7 +276,7 @@ impl Printer {
         } = &c;
         Printer::sig(*idx, params, events, ports, 0, f)?;
         for (idx, param) in params.iter() {
-            Printer::local_param(idx, param, 2, f)?;
+            Printer::local_param(idx, param, 2, c, f)?;
         }
         Printer::interned(exprs, "expr", 2, f)?;
         for (idx, event) in events.iter() {

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -199,7 +199,9 @@ impl Printer {
         indent: usize,
         f: &mut impl io::Write,
     ) -> io::Result<()> {
-        let ir::Port { owner, width, live } = port;
+        let ir::Port {
+            owner, width, live, ..
+        } = port;
         match &owner {
             ir::PortOwner::Sig { .. } => Ok(()),
             ir::PortOwner::Inv { dir, .. } => {

--- a/src/ir/structure.rs
+++ b/src/ir/structure.rs
@@ -234,8 +234,8 @@ pub enum EventOwner {
 /// Events must have a delay and an optional default value
 pub struct Event {
     pub delay: TimeSub,
-    // pub default: Option<TimeIdx>,
     pub owner: EventOwner,
+    pub info: InfoIdx,
 }
 
 impl fmt::Display for Event {

--- a/src/ir/structure.rs
+++ b/src/ir/structure.rs
@@ -109,6 +109,7 @@ pub struct Port {
     pub owner: PortOwner,
     pub width: ExprIdx,
     pub live: Liveness,
+    pub info: InfoIdx,
 }
 impl Port {
     /// Check if this is an input port on the signature

--- a/src/ir/structure.rs
+++ b/src/ir/structure.rs
@@ -1,4 +1,6 @@
-use super::{Ctx, Expr, ExprIdx, InvIdx, ParamIdx, PortIdx, TimeIdx, TimeSub};
+use super::{
+    Ctx, Expr, ExprIdx, InfoIdx, InvIdx, ParamIdx, PortIdx, TimeIdx, TimeSub,
+};
 use std::fmt;
 
 #[derive(PartialEq, Eq, Hash, Clone)]
@@ -196,11 +198,12 @@ impl fmt::Display for ParamOwner {
 /// Parameters with an optional initial value
 pub struct Param {
     pub owner: ParamOwner,
+    pub info: InfoIdx,
 }
 
 impl Param {
-    pub fn new(owner: ParamOwner) -> Self {
-        Self { owner }
+    pub fn new(owner: ParamOwner, info: InfoIdx) -> Self {
+        Self { owner, info }
     }
 
     pub fn is_sig_owned(&self) -> bool {

--- a/src/ir_passes/discharge.rs
+++ b/src/ir_passes/discharge.rs
@@ -147,9 +147,9 @@ impl Discharge {
             self.sol.assert(self.sol.not(self.prop_map[prop])).unwrap();
             let res = self.sol.check().unwrap();
             let out = match res {
-                smt::Response::Sat => {
-                    Some(self.get_assignments(ctx.prop_params(prop)))
-                }
+                smt::Response::Sat => Some(
+                    self.get_assignments(ctx.prop_params(prop.consequent(ctx))),
+                ),
                 smt::Response::Unsat => None,
                 smt::Response::Unknown => panic!("Solver returned unknown"),
             };

--- a/src/ir_passes/discharge.rs
+++ b/src/ir_passes/discharge.rs
@@ -1,5 +1,6 @@
+use crate::ir::Ctx;
 use crate::ir_visitor::{Action, Visitor};
-use crate::{ast, ir};
+use crate::{ast, ir, utils};
 use easy_smt as smt;
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -288,7 +289,16 @@ impl Visitor for Discharge {
         }
 
         match self.check_valid(f.prop, comp) {
-            None => Action::Change(vec![comp.assume(f.prop).into()]),
+            None => {
+                let reason = comp.add(
+                    ir::Reason::misc(
+                        "Discharged assumption",
+                        utils::GPosIdx::UNKNOWN,
+                    )
+                    .into(),
+                );
+                Action::Change(vec![comp.assume(f.prop, reason).into()])
+            }
             Some(assign) => {
                 log::error!(
                     "fact `{}` is not valid. Assignment: {}",

--- a/src/ir_passes/discharge.rs
+++ b/src/ir_passes/discharge.rs
@@ -256,7 +256,7 @@ impl Visitor for Discharge {
         match self.check_valid(f.prop) {
             true => Action::Change(vec![comp.assume(f.prop).into()]),
             false => {
-                log::warn!("fact `{}` is not valid", f.prop);
+                log::warn!("fact `{}` is not valid", comp.display_prop(f.prop));
                 Action::Continue
             }
         }

--- a/src/ir_passes/hoist_facts.rs
+++ b/src/ir_passes/hoist_facts.rs
@@ -55,7 +55,7 @@ impl Visitor for HoistFacts {
             // Otherwise this is a checked assertion that needs to be hoisted.
             // Generate prop = path_cond -> fact.prop
             let cond = self.path_cond(comp).implies(fact.prop, comp);
-            self.facts.push(comp.assert(cond));
+            self.facts.push(ir::Fact::assert(cond, fact.reason));
         }
         Action::Change(vec![])
     }

--- a/src/ir_passes/type_check.rs
+++ b/src/ir_passes/type_check.rs
@@ -31,7 +31,7 @@ impl Visitor for TypeCheck {
         c: &mut ir::Connect,
         comp: &mut ir::Component,
     ) -> Action {
-        let ir::Connect { src, dst } = &c;
+        let ir::Connect { src, dst, .. } = &c;
         let mut cons = vec![];
 
         // Range accesses are well-formed

--- a/src/ir_passes/type_check.rs
+++ b/src/ir_passes/type_check.rs
@@ -34,7 +34,11 @@ impl TypeCheck {
         };
 
         let wf = comp.add(
-            ir::Reason::misc("port access must be well-formed", loc).into(),
+            ir::Reason::misc(
+                "end of port access must greater than the start",
+                loc,
+            )
+            .into(),
         );
 
         let wf_prop = end.gt(start, comp);
@@ -80,15 +84,12 @@ impl Visitor for TypeCheck {
         cons.push(comp.assert(prop, reason));
 
         // Ensure that the sizes are the same
-        let reason = comp.add(
-            ir::Reason::misc(
-                "connected ports must have the same size",
-                GPosIdx::UNKNOWN,
-            )
-            .into(),
-        );
         let src_size = src.end.sub(src.start, comp);
         let dst_size = dst.end.sub(dst.start, comp);
+        let reason = comp.add(
+            ir::Reason::bundle_len_match(dst_loc, src_loc, dst_size, src_size)
+                .into(),
+        );
         let prop = src_size.equal(dst_size, comp);
         cons.push(comp.assert(prop, reason));
 

--- a/src/utils/position.rs
+++ b/src/utils/position.rs
@@ -1,5 +1,5 @@
 //! Tracking of source positions
-use codespan_reporting::files::SimpleFiles;
+use codespan_reporting::{diagnostic::Label, files::SimpleFiles};
 use std::{mem, sync};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
@@ -145,5 +145,19 @@ impl GPosIdx {
         } else {
             Some(self)
         }
+    }
+
+    /// Convert this into a Primary label
+    pub fn primary(self) -> Label<usize> {
+        let table = GlobalPositionTable::as_ref();
+        let pos = table.get_pos(self.0);
+        Label::primary(pos.file.get(), pos.start..pos.end)
+    }
+
+    /// Convert this into a Secondary label
+    pub fn secondary(self) -> Label<usize> {
+        let table = GlobalPositionTable::as_ref();
+        let pos = table.get_pos(self.0);
+        Label::secondary(pos.file.get(), pos.start..pos.end)
     }
 }


### PR DESCRIPTION
Uses the solver to get an assignment that demonstrates that the assert is false.