### PR TITLE
Explicitly print expressions in IR printer

### DIFF
--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -241,18 +241,10 @@ impl Printer<'_> {
         {
             match pos {
                 Position::First((idx, ev)) | Position::Middle((idx, ev)) => {
-                    write!(
-                        f,
-                        "{idx}: {}, ",
-                        self.ctx.display_timesub(&ev.delay)
-                    )?
+                    write!(f, "{idx}: {}, ", self.ctx.display_timesub(&ev.delay))?
                 }
                 Position::Only((idx, ev)) | Position::Last((idx, ev)) => {
-                    write!(
-                        f,
-                        "{idx}: {}",
-                        self.ctx.display_timesub(&ev.delay)
-                    )?
+                    write!(f, "{idx}: {}", self.ctx.display_timesub(&ev.delay))?
                 }
             }
         }

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -241,10 +241,10 @@ impl Printer<'_> {
         {
             match pos {
                 Position::First((idx, ev)) | Position::Middle((idx, ev)) => {
-                    write!(f, "{idx}: {}, ", ev.delay)?
+                    write!(f, "{idx}: {}, ", self.ctx.display_timesub(&ev.delay))?
                 }
                 Position::Only((idx, ev)) | Position::Last((idx, ev)) => {
-                    write!(f, "{idx}: {}", ev.delay)?
+                    write!(f, "{idx}: {}", self.ctx.display_timesub(&ev.delay))?
                 }
             }
         }
@@ -344,6 +344,7 @@ impl Printer<'_> {
     }
 
     fn event(
+        ctx: &ir::Component,
         idx: ir::EventIdx,
         event: &ir::Event,
         indent: usize,
@@ -355,8 +356,8 @@ impl Printer<'_> {
             ir::EventOwner::Inv { inv } => {
                 writeln!(
                     f,
-                    "{:indent$}{idx} = event({inv}), delay: {delay};",
-                    "",
+                    "{:indent$}{idx} = event({inv}), delay: {};",
+                    "", ctx.display_timesub(delay)
                 )
             }
         }
@@ -413,7 +414,7 @@ impl Printer<'_> {
             Printer::local_param(idx, param, 2, ctx, f)?;
         }
         for (idx, event) in ctx.events().iter() {
-            Printer::event(idx, event, 2, f)?;
+            Printer::event(ctx, idx, event, 2, f)?;
         }
         // If debugging is enabled, show the low-level representation of the
         // component's interned values.

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -241,7 +241,11 @@ impl Printer<'_> {
         {
             match pos {
                 Position::First((idx, ev)) | Position::Middle((idx, ev)) => {
-                    write!(f, "{idx}: {}, ", self.ctx.display_timesub(&ev.delay))?
+                    write!(
+                        f,
+                        "{idx}: {}, ",
+                        self.ctx.display_timesub(&ev.delay)
+                    )?
                 }
                 Position::Only((idx, ev)) | Position::Last((idx, ev)) => {
                     write!(f, "{idx}: {}", self.ctx.display_timesub(&ev.delay))?

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -394,7 +394,7 @@ impl Printer<'_> {
             }
             write!(f, "{}", ctx.display(*param))?;
         }
-        writeln!(f, "]")
+        writeln!(f, "];")
     }
 
     pub fn invoke(

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -101,22 +101,6 @@ impl Printer<'_> {
         Ok(())
     }
 
-    fn index_store<T>(
-        store: &ir::IndexStore<T>,
-        op: &str,
-        indent: usize,
-        f: &mut impl io::Write,
-    ) -> io::Result<()>
-    where
-        T: Display,
-        Idx<T>: Display,
-    {
-        for (i, v) in store.iter() {
-            writeln!(f, "{:indent$}{i} = {op} {v};", "")?;
-        }
-        Ok(())
-    }
-
     fn expr(&self, e: ir::ExprIdx) -> String {
         self.ctx.display(e)
     }
@@ -441,7 +425,6 @@ impl Printer<'_> {
         for (idx, port) in ctx.ports().iter() {
             printer.local_port(idx, port, 2, f)?;
         }
-        //Printer::index_store(ctx.instances(), "instance", 2, f)?;
         for (idx, instance) in ctx.instances().iter() {
             Printer::instance(ctx,idx,instance,2,f)?;
         }

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -242,15 +242,15 @@ impl Printer<'_> {
             match pos {
                 Position::First((idx, ev)) | Position::Middle((idx, ev)) => {
                     write!(
-                        f, 
-                        "{idx}: {}, ", 
+                        f,
+                        "{idx}: {}, ",
                         self.ctx.display_timesub(&ev.delay)
                     )?
                 }
                 Position::Only((idx, ev)) | Position::Last((idx, ev)) => {
                     write!(
-                        f, 
-                        "{idx}: {}", 
+                        f,
+                        "{idx}: {}",
                         self.ctx.display_timesub(&ev.delay)
                     )?
                 }
@@ -365,7 +365,7 @@ impl Printer<'_> {
                 writeln!(
                     f,
                     "{:indent$}{idx} = event({inv}), delay: {};",
-                    "", 
+                    "",
                     ctx.display_timesub(delay)
                 )
             }

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -367,10 +367,10 @@ impl Printer<'_> {
         idx: ir::InstIdx,
         inst: &ir::Instance,
         indent: usize,
-        f: &mut impl io::Write
+        f: &mut impl io::Write,
     ) -> io::Result<()> {
-        write!(f, "{:indent$}{idx} = instance ","")?;
-        let ir::Instance {comp, params} = inst;
+        write!(f, "{:indent$}{idx} = instance ", "")?;
+        let ir::Instance { comp, params } = inst;
         write!(f, "{}[", comp)?;
         for (i, param) in params.iter().enumerate() {
             if i != 0 {
@@ -426,7 +426,7 @@ impl Printer<'_> {
             printer.local_port(idx, port, 2, f)?;
         }
         for (idx, instance) in ctx.instances().iter() {
-            Printer::instance(ctx,idx,instance,2,f)?;
+            Printer::instance(ctx, idx, instance, 2, f)?;
         }
         for (idx, invoke) in ctx.invocations().iter() {
             Printer::invoke(idx, invoke, 2, f)?;

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -378,6 +378,25 @@ impl Printer<'_> {
         }
     }
 
+    pub fn instance(
+        ctx: &ir::Component,
+        idx: ir::InstIdx,
+        inst: &ir::Instance,
+        indent: usize,
+        f: &mut impl io::Write
+    ) -> io::Result<()> {
+        write!(f, "{:indent$}{idx} = instance ","")?;
+        let ir::Instance {comp, params} = inst;
+        write!(f, "{}[", comp)?;
+        for (i, param) in params.iter().enumerate() {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", ctx.display(*param))?;
+        }
+        writeln!(f, "]")
+    }
+
     pub fn invoke(
         idx: ir::InvIdx,
         c: &ir::Invoke,
@@ -422,7 +441,10 @@ impl Printer<'_> {
         for (idx, port) in ctx.ports().iter() {
             printer.local_port(idx, port, 2, f)?;
         }
-        Printer::index_store(ctx.instances(), "instance", 2, f)?;
+        //Printer::index_store(ctx.instances(), "instance", 2, f)?;
+        for (idx, instance) in ctx.instances().iter() {
+            Printer::instance(ctx,idx,instance,2,f)?;
+        }
         for (idx, invoke) in ctx.invocations().iter() {
             Printer::invoke(idx, invoke, 2, f)?;
         }

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -241,10 +241,18 @@ impl Printer<'_> {
         {
             match pos {
                 Position::First((idx, ev)) | Position::Middle((idx, ev)) => {
-                    write!(f, "{idx}: {}, ", self.ctx.display_timesub(&ev.delay))?
+                    write!(
+                        f, 
+                        "{idx}: {}, ", 
+                        self.ctx.display_timesub(&ev.delay)
+                    )?
                 }
                 Position::Only((idx, ev)) | Position::Last((idx, ev)) => {
-                    write!(f, "{idx}: {}", self.ctx.display_timesub(&ev.delay))?
+                    write!(
+                        f, 
+                        "{idx}: {}", 
+                        self.ctx.display_timesub(&ev.delay)
+                    )?
                 }
             }
         }
@@ -357,7 +365,8 @@ impl Printer<'_> {
                 writeln!(
                     f,
                     "{:indent$}{idx} = event({inv}), delay: {};",
-                    "", ctx.display_timesub(delay)
+                    "", 
+                    ctx.display_timesub(delay)
                 )
             }
         }


### PR DESCRIPTION
Exprs were getting printed in the IR as `%e0` (and so on), so now we print what they actually are. Some examples:

1. In a component signature, we were previously printing `comp %comp1[...]<%ev0: %e0>(...)`, but now it looks like `comp %comp1[...]<%ev0: 1>(...)` (or whatever the delay of the event is). The same change happens in component bodies, where we print out events.
2. In instantiations, we were previously printing `%inst0 = instance %comp0[%e0];`, but now it looks like `%inst0 = instance %comp0[#W];`.