### PR TITLE
add gitignore for data.json in reticle

### DIFF
--- a/reticle/.gitignore
+++ b/reticle/.gitignore
@@ -1,0 +1,1 @@
+data.json


### PR DESCRIPTION
Very small pull request, data.json is automatically generated by runt and not gitignored at the moment.