### PR TITLE
Fix minor typo

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -16,7 +16,7 @@ pub struct Opts {
     #[argh(switch, long = "show-ir")]
     pub show_ir: bool,
 
-    /// print out assignments that falisfy the constraints
+    /// print out assignments that falsify the constraints
     #[argh(switch, long = "show-models")]
     pub show_models: bool,
 


### PR DESCRIPTION
Fixes a minor typo of falsify.

> Just touring the code base after watching the excellent recent talk from @rachitnigam. Noticed this tiny one and thought I would get my feet wet with the contribution flow :) Excited by the direction of filament and looking forward to contributing more!