### PR TITLE
fix optional parameter generation

### DIFF
--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -38,9 +38,9 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
         );
         let inst = ir::Instance {
             comp: comp.idx,
-            params: bindings
+            params: binding
                 .iter()
-                .map(|b| self.expr(b.clone().take()))
+                .map(|(_, b)| self.expr(b.clone()))
                 .collect_vec()
                 .into_boxed_slice(),
         };


### PR DESCRIPTION
Fixes #204. Fixes instance declaration in `astconv.rs` to generate missing optional parameters.