### PR TITLE
`let`-bound parameters

### DIFF
--- a/src/ast/component.rs
+++ b/src/ast/component.rs
@@ -40,7 +40,8 @@ impl Component {
                 | Command::Fact(_)
                 | Command::Bundle(_)
                 | Command::If(_)
-                | Command::ForLoop(_) => (),
+                | Command::ForLoop(_)
+                | Command::ParamLet(_) => (),
             }
         }
 

--- a/src/ast/control.rs
+++ b/src/ast/control.rs
@@ -159,8 +159,15 @@ pub enum Command {
     Fact(Fact),
     Connect(Connect),
     ForLoop(ForLoop),
+    ParamLet(ParamLet),
     If(If),
     Bundle(Bundle),
+}
+
+impl From<ParamLet> for Command {
+    fn from(v: ParamLet) -> Self {
+        Self::ParamLet(v)
+    }
 }
 
 impl From<Connect> for Command {
@@ -202,6 +209,7 @@ impl Display for Command {
             Command::If(l) => write!(f, "{}", l),
             Command::Bundle(b) => write!(f, "{b}"),
             Command::Fact(a) => write!(f, "{a}"),
+            Command::ParamLet(l) => write!(f, "{l}"),
         }
     }
 }
@@ -681,5 +689,19 @@ impl Display for Bundle {
             "for<#{}> {} {};",
             self.typ.idx, self.typ.liveness, self.typ.bitwidth
         )
+    }
+}
+
+/// A let-bound parameter
+#[derive(Clone)]
+pub struct ParamLet {
+    pub name: Loc<Id>,
+    /// The expression for the parameter binding
+    pub expr: Expr,
+}
+
+impl Display for ParamLet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "let {} = {};", self.name, self.expr)
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -14,7 +14,7 @@ pub use component::{Component, Namespace};
 pub use constraint::{Constraint, OrderConstraint, OrderOp};
 pub use control::{
     Access, Bundle, BundleType, Command, Connect, Fact, ForLoop, Fsm, Guard,
-    If, Instance, Invoke, Port,
+    If, Instance, Invoke, ParamLet, Port,
 };
 pub use expr::{EvalBool, Expr, FnAssume, Op, UnFn};
 pub use id::Id;

--- a/src/backend/compile.rs
+++ b/src/backend/compile.rs
@@ -428,6 +428,9 @@ fn compile_component(
             ast::Command::Fact(a) => {
                 unreachable!("Assumption `{a}' should have been compiled away.")
             }
+            ast::Command::ParamLet(_) => {
+                unreachable!("Let binding should be compiled away")
+            }
         };
     }
     // Compile commands

--- a/src/binding/comp.rs
+++ b/src/binding/comp.rs
@@ -190,7 +190,9 @@ impl BoundComponent {
                     self.process_cmds(prog, &if_.then);
                     self.process_cmds(prog, &if_.alt);
                 }
-                ast::Command::Connect(_) | ast::Command::Fact(_) => (),
+                ast::Command::Connect(_)
+                | ast::Command::Fact(_)
+                | ast::Command::ParamLet(_) => (),
             }
         }
     }
@@ -328,7 +330,7 @@ impl BoundComponent {
                 ast::Command::Bundle(bl) => {
                     self.add_bundle(bl.clone());
                 }
-                ast::Command::Fact(_) => (),
+                ast::Command::Fact(_) | ast::Command::ParamLet(_) => (),
             }
         }
     }

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -682,6 +682,13 @@ impl FilamentParser {
         ))
     }
 
+    fn param_let(input: Node) -> ParseResult<ast::ParamLet> {
+        Ok(match_nodes!(
+            input.into_children();
+            [param_var(name), expr(expr)] => ast::ParamLet { name, expr: expr.take() }
+        ))
+    }
+
     fn command(input: Node) -> ParseResult<Vec<ast::Command>> {
         Ok(match_nodes!(
             input.into_children();
@@ -691,6 +698,7 @@ impl FilamentParser {
             [for_loop(l)] => vec![ast::Command::ForLoop(l)],
             [bundle(bl)] => vec![bl.into()],
             [if_stmt(if_)] => vec![if_.into()],
+            [param_let(l)] => vec![l.into()],
             [fact(a)] => vec![a.into()]
         ))
     }

--- a/src/frontend/syntax.pest
+++ b/src/frontend/syntax.pest
@@ -194,6 +194,11 @@ if_stmt = {
   "if" ~ expr_cmp ~ "{" ~ commands ~ "}" ~ ("else" ~ "{" ~ commands ~ "}")?
 }
 
+// ===== let-bound parameters ========
+param_let = {
+  "let" ~ param_var ~ "=" ~ expr ~ ";"
+}
+
 // ====== Loops ==========
 
 for_loop = {
@@ -222,7 +227,7 @@ fact = {
 
 // ========== Commands ==========
 command = {
-  bundle | instance | invocation | connect | for_loop | if_stmt | fact
+  bundle | instance | invocation | connect | for_loop | if_stmt | fact | param_let
 }
 
 commands = { command* }

--- a/src/ir/control.rs
+++ b/src/ir/control.rs
@@ -15,6 +15,12 @@ pub enum Command {
     If(If),
     Fact(Fact),
     EventBind(EventBind),
+    Let(Let),
+}
+impl From<Let> for Command {
+    fn from(value: Let) -> Self {
+        Command::Let(value)
+    }
 }
 impl From<InstIdx> for Command {
     fn from(idx: InstIdx) -> Self {
@@ -128,4 +134,11 @@ impl EventBind {
     pub fn new(event: EventIdx, arg: TimeIdx, info: InfoIdx) -> Self {
         Self { event, arg, info }
     }
+}
+
+/// A let-bound parameter in the program
+#[derive(Clone, PartialEq, Eq)]
+pub struct Let {
+    pub param: ParamIdx,
+    pub expr: ExprIdx,
 }

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -111,7 +111,8 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
             | ast::Command::If(_)
             | ast::Command::Fact(_)
             | ast::Command::Connect(_)
-            | ast::Command::Bundle(_) => {}
+            | ast::Command::Bundle(_)
+            | ast::Command::ParamLet(_) => {}
         }
     }
 
@@ -729,6 +730,14 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
                 let src = self.get_access(src.take(), ir::Direction::Out);
                 let dst = self.get_access(dst.take(), ir::Direction::In);
                 vec![ir::Connect { src, dst, info }.into()]
+            }
+            ast::Command::ParamLet(ast::ParamLet { name, expr }) => {
+                let param = self.param(
+                    &ast::ParamBind::new(name, None),
+                    ir::ParamOwner::Let,
+                );
+                let expr = self.expr(expr);
+                vec![ir::Let { param, expr }.into()]
             }
             ast::Command::ForLoop(ast::ForLoop {
                 idx,

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -13,7 +13,9 @@ mod time;
 mod utils;
 
 pub use comp::{Component, Context};
-pub use control::{Command, Connect, EventBind, If, Instance, Invoke, Loop};
+pub use control::{
+    Command, Connect, EventBind, If, Instance, Invoke, Let, Loop,
+};
 pub use ctx::{Ctx, MutCtx};
 pub use expr::Expr;
 pub use fact::{Cmp, CmpOp, Fact, Prop};

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -204,6 +204,9 @@ impl Printer<'_> {
                     write!(f, "{:indent$}assume {};", "", fact.prop)
                 }
             }
+            ir::Command::Let(ir::Let { param, expr }) => {
+                write!(f, "{:indent$}let {param} = {};", "", self.expr(*expr))
+            }
         }
     }
 

--- a/src/ir/structure.rs
+++ b/src/ir/structure.rs
@@ -236,6 +236,8 @@ pub enum ParamOwner {
     Bundle(PortIdx),
     /// Loop indexing parameter
     Loop,
+    /// A let-bound parameter`
+    Let,
 }
 
 impl ParamOwner {
@@ -250,6 +252,7 @@ impl fmt::Display for ParamOwner {
             Self::Sig => write!(f, "sig"),
             Self::Bundle(p) => write!(f, "bundle({p})"),
             Self::Loop => write!(f, "loop"),
+            Self::Let => write!(f, "let"),
         }
     }
 }
@@ -258,8 +261,9 @@ impl fmt::Display for ParamOwner {
 /// Parameters with an optional initial value
 pub struct Param {
     pub owner: ParamOwner,
-    pub info: InfoIdx,
+    /// The default value for this parameter
     pub default: Option<ExprIdx>,
+    pub info: InfoIdx,
 }
 
 impl Param {

--- a/src/ir_visitor/visitor.rs
+++ b/src/ir_visitor/visitor.rs
@@ -148,6 +148,14 @@ where
         Action::Continue
     }
 
+    fn param_let(
+        &mut self,
+        _: &mut ir::Let,
+        _comp: &mut ir::Component,
+    ) -> Action {
+        Action::Continue
+    }
+
     fn visit_cmd(
         &mut self,
         cmd: &mut ir::Command,
@@ -161,6 +169,7 @@ where
             ir::Command::If(i) => self.do_if(i, comp),
             ir::Command::Fact(f) => self.fact(f, comp),
             ir::Command::EventBind(eb) => self.event_binding(eb, comp),
+            ir::Command::Let(l) => self.param_let(l, comp),
         }
     }
 

--- a/src/passes/bind_check.rs
+++ b/src/passes/bind_check.rs
@@ -105,6 +105,15 @@ impl visitor::Checker for BindCheck {
         Traverse::Continue(())
     }
 
+    fn param_let(
+        &mut self,
+        l: &ast::ParamLet,
+        _ctx: &binding::CompBinding,
+    ) -> Traverse {
+        self.add_global_params(vec![l.name.clone()].into_iter());
+        Traverse::Continue(())
+    }
+
     fn bundle(
         &mut self,
         _is_port: bool,

--- a/src/passes/bundle_elim.rs
+++ b/src/passes/bundle_elim.rs
@@ -299,7 +299,9 @@ impl BundleElim {
                     let alt = self.commands(alt);
                     vec![ast::If { cond, then, alt }.into()]
                 }
-                c @ (ast::Command::Bundle(_) | ast::Command::Fact(_)) => {
+                c @ (ast::Command::ParamLet(_)
+                | ast::Command::Bundle(_)
+                | ast::Command::Fact(_)) => {
                     vec![c]
                 }
             })

--- a/src/passes/monomorphize/mono.rs
+++ b/src/passes/monomorphize/mono.rs
@@ -305,6 +305,7 @@ impl<'e> Monomorphize<'e> {
                         n_cmds.extend(rw.rewrite(ncmds));
                     }
                 }
+                ast::Command::ParamLet(_) => todo!(),
             }
         }
         n_cmds

--- a/src/passes/monomorphize/rewriter.rs
+++ b/src/passes/monomorphize/rewriter.rs
@@ -68,6 +68,7 @@ impl Rewriter {
                     )
                 }
                 ast::Command::Connect(_) | ast::Command::Fact(_) => {}
+                ast::Command::ParamLet(_) => todo!(),
             }
         }
         let mut n_cmds = Vec::with_capacity(cmds.len());
@@ -127,6 +128,7 @@ impl Rewriter {
                 ast::Command::If(_)
                 | ast::Command::ForLoop(_)
                 | ast::Command::Fact(_) => unreachable!(),
+                ast::Command::ParamLet(_) => todo!(),
             };
             n_cmds.push(out);
         }

--- a/src/utils/post_order.rs
+++ b/src/utils/post_order.rs
@@ -78,7 +78,8 @@ fn process_cmd(
         ast::Command::Connect(_)
         | ast::Command::Invoke(_)
         | ast::Command::Bundle(_)
-        | ast::Command::Fact(_) => (),
+        | ast::Command::Fact(_)
+        | ast::Command::ParamLet(_) => (),
     }
 }
 

--- a/src/visitor/checker.rs
+++ b/src/visitor/checker.rs
@@ -109,6 +109,7 @@ where
             ast::Command::Connect(con) => self.connect(con, ctx),
             ast::Command::ForLoop(l) => self.forloop(l, ctx),
             ast::Command::If(i) => self.if_(i, ctx),
+            ast::Command::ParamLet(_) => todo!(),
         }
     }
 

--- a/src/visitor/checker.rs
+++ b/src/visitor/checker.rs
@@ -64,6 +64,10 @@ where
     ) -> Traverse {
         Traverse::Continue(())
     }
+    #[inline]
+    fn param_let(&mut self, _: &ast::ParamLet, _ctx: &CompBinding) -> Traverse {
+        Traverse::Continue(())
+    }
 
     #[inline]
     fn signature(&mut self, _: &ast::Signature) -> Traverse {
@@ -109,7 +113,7 @@ where
             ast::Command::Connect(con) => self.connect(con, ctx),
             ast::Command::ForLoop(l) => self.forloop(l, ctx),
             ast::Command::If(i) => self.if_(i, ctx),
-            ast::Command::ParamLet(_) => todo!(),
+            ast::Command::ParamLet(l) => self.param_let(l, ctx),
         }
     }
 

--- a/src/visitor/visit.rs
+++ b/src/visitor/visit.rs
@@ -144,6 +144,7 @@ where
                     ast::Command::If(_) => unreachable!(
                         "Visitor does not support transforming if statements"
                     ),
+                    ast::Command::ParamLet(_) => todo!(),
                 };
                 n_cmds.extend(cmds);
             }


### PR DESCRIPTION
Adds new syntax for `let`-bound parameters. Only works for the IR flow.
