### PR TITLE
Add find() function for DenseIndexInfo

### DIFF
--- a/src/ir/utils.rs
+++ b/src/ir/utils.rs
@@ -277,6 +277,15 @@ impl<T, V> DenseIndexInfo<T, V> {
     pub fn contains(&self, idx: Idx<T>) -> bool {
         idx.get() < self.store.len()
     }
+
+    /// Get the value associated with the index if present, otherwise return None.
+    pub fn find(&self, idx: Idx<T>) -> Option<&V> {
+        if self.contains(idx) {
+            Some(self.get(idx))
+        } else {
+            None
+        }
+    }
 }
 
 impl<T, V> std::ops::Index<Idx<T>> for DenseIndexInfo<T, V> {


### PR DESCRIPTION
Adds a `find()` function for DenseIndexInfo that returns a `Some` if the given index is in the mapping and `None` if not. Intended for use in monomorphization, but probably also generally useful.

closes #229 