### PR TITLE
[NFC] Some IR cleanup

### DIFF
--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -152,7 +152,7 @@ impl Component {
     /// Panic with an error message and display the current state of the Component. Prefer this over `panic!` when possible.
     pub fn internal_error<S: ToString>(&self, msg: S) -> ! {
         let comp = super::Printer::comp_str(self);
-        panic!("{}\n{comp}", msg.to_string())
+        panic!("{comp}\n{}", msg.to_string())
     }
 }
 

--- a/src/ir/control.rs
+++ b/src/ir/control.rs
@@ -2,7 +2,6 @@ use super::{
     Access, CompIdx, Component, Ctx, Event, ExprIdx, Fact, Foreign, InfoIdx,
     InstIdx, InvIdx, ParamIdx, PortIdx, PropIdx, TimeIdx, TimeSub,
 };
-use std::fmt;
 
 #[derive(Clone, PartialEq, Eq)]
 /// A flattened and minimized representation of the control flow graph.
@@ -57,19 +56,6 @@ pub struct Instance {
     pub info: InfoIdx,
 }
 
-impl fmt::Display for Instance {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}[", self.comp)?;
-        for (i, param) in self.params.iter().enumerate() {
-            if i != 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "{}", param)?;
-        }
-        write!(f, "]")
-    }
-}
-
 impl InstIdx {
     /// Gets the component being instantiated
     pub fn comp(self, ctx: &impl Ctx<Instance>) -> CompIdx {
@@ -84,11 +70,6 @@ pub struct Connect {
     pub src: Access,
     pub dst: Access,
     pub info: InfoIdx,
-}
-impl fmt::Display for Connect {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} = {}", self.dst, self.src)
-    }
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -1,7 +1,6 @@
-use std::fmt::Display;
-
 use super::{Cmp, CmpOp, Ctx, ExprIdx, ParamIdx, Prop, PropIdx};
 use crate::ast;
+use std::fmt::Display;
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub enum Expr {

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -752,9 +752,8 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
                 invoke.events.push(eb);
             });
 
-        connects
-            .into_iter()
-            .chain(Some(ir::Command::from(inv)))
+        std::iter::once(ir::Command::from(inv))
+            .chain(connects)
             .chain(cons)
             .collect_vec()
     }

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -221,10 +221,9 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
         param: &ast::ParamBind,
         owner: ir::ParamOwner,
     ) -> ParamIdx {
-        let default = param.default.as_ref().map(|e| self.expr(e.clone()));
         let info = self.comp.add(ir::Info::param(param.name(), param.pos()));
 
-        let ir_param = ir::Param::new(owner, info, default);
+        let ir_param = ir::Param::new(owner, info);
         let is_sig_param = ir_param.is_sig_owned();
 
         let idx = self.comp.add(ir_param);

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -43,7 +43,7 @@ impl DisplayCtx<ir::Event> for ir::Component {
         } else {
             let ev = self.get(idx);
             let ir::Info::Event { name, .. } = self.get(ev.info) else {
-                unreachable!("Expccted event info")
+                unreachable!("Expected event info")
             };
             name.to_string()
         }
@@ -106,7 +106,7 @@ impl Printer<'_> {
 
     fn range(&self, r: &ir::Range) -> String {
         let ir::Range { start, end } = r;
-        format!("@[{}, {}]", self.time(*start), self.time(*end))
+        format!("[{}, {}]", self.time(*start), self.time(*end))
     }
 
     fn liveness(&self, l: &ir::Liveness) -> String {
@@ -222,10 +222,10 @@ impl Printer<'_> {
         {
             match pos {
                 Position::First(idx) | Position::Middle(idx) => {
-                    write!(f, "{idx}, ")?
+                    write!(f, "{}, ", self.ctx.display(idx))?
                 }
                 Position::Only(idx) | Position::Last(idx) => {
-                    write!(f, "{idx}")?
+                    write!(f, "{}", self.ctx.display(idx))?
                 }
             }
         }
@@ -236,12 +236,18 @@ impl Printer<'_> {
                 Position::First((idx, ev)) | Position::Middle((idx, ev)) => {
                     write!(
                         f,
-                        "{idx}: {}, ",
+                        "{}: {}, ",
+                        self.ctx.display(idx),
                         self.ctx.display_timesub(&ev.delay)
                     )?
                 }
                 Position::Only((idx, ev)) | Position::Last((idx, ev)) => {
-                    write!(f, "{idx}: {}", self.ctx.display_timesub(&ev.delay))?
+                    write!(
+                        f,
+                        "{}: {}",
+                        self.ctx.display(idx),
+                        self.ctx.display_timesub(&ev.delay)
+                    )?
                 }
             }
         }
@@ -635,6 +641,6 @@ impl ir::Component {
 
     /// Surface-level visualization for a range
     pub fn display_range(&self, r: &ir::Range) -> String {
-        format!("@[{}, {}]", self.display(r.start), self.display(r.end))
+        format!("[{}, {}]", self.display(r.start), self.display(r.end))
     }
 }

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -164,12 +164,16 @@ impl Printer<'_> {
 
     fn access(&self, a: &ir::Access) -> String {
         let &ir::Access { port, start, end } = a;
-        format!(
-            "{}[{}..{})",
-            self.ctx.display(port),
-            self.expr(start),
-            self.expr(end)
-        )
+        if a.is_port(self.ctx) {
+            self.ctx.display(port)
+        } else {
+            format!(
+                "{}[{}..{})",
+                self.ctx.display(port),
+                self.expr(start),
+                self.expr(end)
+            )
+        }
     }
 
     fn connect(

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -209,13 +209,12 @@ impl Printer<'_> {
         if comp.is_ext {
             write!(f, "ext ")?;
         };
-        if let Some(idx) = idx {
+        if let Some(info) = &comp.src_info {
+            write!(f, "comp {}", info.name)?
+        } else if let Some(idx) = idx {
             write!(f, "comp {}", idx)?;
         } else {
             write!(f, "comp")?;
-        }
-        if let Some(info) = &comp.src_info {
-            write!(f, " ({})", info.name)?
         }
         write!(f, "[")?;
         for pos in comp

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -684,6 +684,6 @@ impl ir::Component {
 
     /// Surface-level visualization for a range
     pub fn display_range(&self, r: &ir::Range) -> String {
-        format!("[{}, {}]", self.display(r.start), self.display(r.end))
+        format!("@[{}, {}]", self.display(r.start), self.display(r.end))
     }
 }

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -384,10 +384,7 @@ impl Printer<'_> {
             "{:indent$}{idx}, {ports} = invoke {inst}<{events}>;",
             "",
             ports = ports.iter().map(|p| format!("{p}")).join(", "),
-            events = events
-                .iter()
-                .map(|e| self.ctx.display_timesub(&e.delay))
-                .join(", ")
+            events = events.iter().map(|e| self.ctx.display(e.arg)).join(", ")
         )?;
 
         Ok(())

--- a/src/ir/structure.rs
+++ b/src/ir/structure.rs
@@ -285,20 +285,11 @@ impl fmt::Display for ParamOwner {
 pub struct Param {
     pub owner: ParamOwner,
     pub info: InfoIdx,
-    pub default: Option<ExprIdx>,
 }
 
 impl Param {
-    pub fn new(
-        owner: ParamOwner,
-        info: InfoIdx,
-        default: Option<ExprIdx>,
-    ) -> Self {
-        Self {
-            owner,
-            info,
-            default,
-        }
+    pub fn new(owner: ParamOwner, info: InfoIdx) -> Self {
+        Self { owner, info }
     }
 
     pub fn is_sig_owned(&self) -> bool {
@@ -312,9 +303,6 @@ impl Param {
 
 impl fmt::Display for Param {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(default) = self.default {
-            write!(f, "{} ", default)?;
-        }
         write!(f, "{}", self.owner)
     }
 }

--- a/src/ir/structure.rs
+++ b/src/ir/structure.rs
@@ -204,8 +204,10 @@ impl Access {
     /// Check if this is guaranteed a simple port access, i.e., an access that
     /// produces one port.
     /// The check is syntactic and therefore conservative.
-    pub fn is_port(&self, ctx: &mut impl Ctx<Expr>) -> bool {
-        let one = ctx.add(Expr::Concrete(1));
+    pub fn is_port(&self, ctx: &Component) -> bool {
+        let Some(one) = ctx.exprs().find(&Expr::Concrete(1)) else {
+            ctx.internal_error("Constant 1 not found in component")
+        };
         match ctx.get(self.end) {
             Expr::Bin {
                 op: Op::Add,

--- a/src/ir/structure.rs
+++ b/src/ir/structure.rs
@@ -1,9 +1,8 @@
-use crate::ast::Op;
-
 use super::{
     utils::Foreign, Bind, Component, Ctx, Expr, ExprIdx, Foldable, InfoIdx,
     InvIdx, ParamIdx, PortIdx, Subst, TimeIdx, TimeSub,
 };
+use crate::ast::Op;
 use std::fmt;
 
 #[derive(PartialEq, Eq, Hash, Clone)]
@@ -11,12 +10,6 @@ use std::fmt;
 pub struct Range {
     pub start: TimeIdx,
     pub end: TimeIdx,
-}
-
-impl fmt::Display for Range {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "@[{}, {}]", self.start, self.end)
-    }
 }
 
 impl Foldable<ParamIdx, ExprIdx> for Range {
@@ -47,16 +40,6 @@ pub enum PortOwner {
     /// The port is defined locally.
     /// It does not have a direction because both reading and writing to it is allowed.
     Local,
-}
-
-impl fmt::Display for PortOwner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Sig { dir } => write!(f, "sig({})", dir),
-            Self::Inv { inv, dir, .. } => write!(f, "{}({})", inv, dir),
-            Self::Local => write!(f, "local"),
-        }
-    }
 }
 
 impl PortOwner {
@@ -129,12 +112,6 @@ pub struct Liveness {
     pub range: Range,
 }
 
-impl fmt::Display for Liveness {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "for<{}: {}> {}", self.idx, self.len, self.range)
-    }
-}
-
 #[derive(PartialEq, Eq, Hash, Clone)]
 /// A port tracks its definition and liveness.
 /// A port in the IR generalizes both bundles and normal ports.
@@ -170,11 +147,6 @@ impl Port {
     pub fn is_sig_out(&self) -> bool {
         // We check the direction is `in` because the port direction is flipped
         matches!(self.owner, PortOwner::Sig { dir: Direction::In })
-    }
-}
-impl fmt::Display for Port {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {}", self.owner, self.live, self.width)
     }
 }
 
@@ -249,11 +221,6 @@ impl Access {
         }
     }
 }
-impl fmt::Display for Access {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}[{}..{})", self.port, self.start, self.end)
-    }
-}
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 /// Construct that defines the parameter
@@ -269,16 +236,6 @@ pub enum ParamOwner {
 impl ParamOwner {
     pub fn bundle(port: PortIdx) -> Self {
         Self::Bundle(port)
-    }
-}
-
-impl fmt::Display for ParamOwner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Sig => write!(f, "sig"),
-            Self::Bundle(p) => write!(f, "bundle({p})"),
-            Self::Loop => write!(f, "loop"),
-        }
     }
 }
 
@@ -303,22 +260,10 @@ impl Param {
     }
 }
 
-impl fmt::Display for Param {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.owner)
-    }
-}
-
 #[derive(PartialEq, Eq, Hash, Clone)]
 /// Events must have a delay and an optional default value
 pub struct Event {
     pub delay: TimeSub,
     pub info: InfoIdx,
     pub has_interface: bool,
-}
-
-impl fmt::Display for Event {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "delay {}", self.delay)
-    }
 }

--- a/src/ir/utils.rs
+++ b/src/ir/utils.rs
@@ -57,6 +57,11 @@ where
         idx
     }
 
+    /// Return the index of the value if it is in the store
+    pub fn find(&self, val: &T) -> Option<Idx<T>> {
+        self.map.get(val).copied()
+    }
+
     /// Number of interned values in the store.
     pub fn size(&self) -> usize {
         self.store.len()

--- a/src/ir_passes/lower/build_ctx.rs
+++ b/src/ir_passes/lower/build_ctx.rs
@@ -157,7 +157,8 @@ impl<'a> BuildCtx<'a> {
 
         assert!(
             start.event == end.event,
-            "Range `{range}` cannot be represented as a simple offset"
+            "Range `{}` cannot be represented as a simple offset",
+            self.comp.display_range(range)
         );
 
         let ev = start.event;
@@ -213,7 +214,10 @@ impl<'a> BuildCtx<'a> {
             "Port bundles should have been compiled away."
         );
 
-        log::debug!("Compiling connect: {}", con);
+        log::debug!(
+            "Compiling connect: {}",
+            ir::Printer::new(self.comp).connect_str(con)
+        );
 
         // ignores the guard of the destination (bind check already verifies that it is available for at least as long as src)
         let (dst, _) = self.compile_port(dst.port);

--- a/src/ir_passes/lower/compile.rs
+++ b/src/ir_passes/lower/compile.rs
@@ -87,7 +87,6 @@ impl Compile {
                 comp.events()
                     .idx_iter()
                     .filter_map(|idx| interface_name(idx, comp))
-                    .into_iter()
                     .map(|name| calyx::PortDef {
                         name: name.into(),
                         width: width_from_u64(1),


### PR DESCRIPTION
Mostly makes the printer use the `Info` data to print out components so that they better match their source-level representation and removes `std::fmt` implementations from IR nodes. The IR printer should be the only way to print meaningful values from the IR.