### PR TITLE
Add simplification for expressions upon addition

### DIFF
--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -339,7 +339,50 @@ impl Ctx<Invoke> for Component {
 
 impl Ctx<Expr> for Component {
     fn add(&mut self, val: Expr) -> ExprIdx {
-        self.exprs.intern(val)
+        match &val {
+            Expr::Param(_) | Expr::Concrete(_) => self.exprs.intern(val),
+            Expr::Bin { op, lhs, rhs } => {
+                let l = lhs.as_concrete(self);
+                let r = rhs.as_concrete(self);
+                let e = match (l, r) {
+                    (Some(0), Some(r)) => Expr::Concrete(r),
+                    (Some(l), Some(0)) => Expr::Concrete(l),
+                    (Some(0), None) => return *rhs,
+                    (None, Some(0)) => return *lhs,
+                    (Some(l), None) => {
+                        if matches!(op, ast::Op::Add | ast::Op::Mul) {
+                            // moves all constants to the right side of non-ordered expressions
+                            Expr::Bin {
+                                op: *op,
+                                lhs: *rhs,
+                                rhs: self.exprs.intern(Expr::Concrete(l)),
+                            }
+                        } else {
+                            val
+                        }
+                    }
+                    (Some(l), Some(r)) => Expr::Concrete(match op {
+                        ast::Op::Add => l + r,
+                        ast::Op::Sub => l - r,
+                        ast::Op::Mul => l * r,
+                        ast::Op::Div => l / r,
+                        ast::Op::Mod => l % r,
+                    }),
+                    _ => val,
+                };
+                self.exprs.intern(e)
+            }
+            Expr::Fn { op, args } => self.exprs.intern(
+                args.iter()
+                    .map(|arg| arg.as_concrete(self))
+                    .collect::<Option<Vec<_>>>()
+                    .map(|args| match op {
+                        ast::UnFn::Pow2 => 1u64 << args[0],
+                        ast::UnFn::Log2 => args[0].trailing_zeros() as u64,
+                    })
+                    .map_or(val, Expr::Concrete),
+            ),
+        }
     }
 
     fn get(&self, idx: ExprIdx) -> &Expr {

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -345,8 +345,6 @@ impl Ctx<Expr> for Component {
                 let l = lhs.as_concrete(self);
                 let r = rhs.as_concrete(self);
                 let e = match (l, r) {
-                    (Some(0), Some(r)) => Expr::Concrete(r),
-                    (Some(l), Some(0)) => Expr::Concrete(l),
                     (Some(0), None) => return *rhs,
                     (None, Some(0)) => return *lhs,
                     (Some(l), None) => {

--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -101,132 +101,57 @@ impl ExprIdx {
 
     /// Adds two expressions together.
     pub fn add(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
-        let l = self.as_concrete(ctx);
-        let r = other.as_concrete(ctx);
-
-        match (l, r) {
-            (Some(l), Some(r)) => ctx.add(Expr::Concrete(l + r)),
-            (None, Some(0)) => self,
-            (Some(0), None) => other,
-            _ => {
-                // Sort the operands to canonicalize the expression
-                let (lhs, rhs) = if self < other {
-                    (self, other)
-                } else {
-                    (other, self)
-                };
-                ctx.add(Expr::Bin {
-                    op: ast::Op::Add,
-                    lhs,
-                    rhs,
-                })
-            }
-        }
+        ctx.add(Expr::Bin {
+            op: ast::Op::Add,
+            lhs: self,
+            rhs: other,
+        })
     }
 
     pub fn mul(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
-        let l = self.as_concrete(ctx);
-        let r = other.as_concrete(ctx);
-
-        match (l, r) {
-            (Some(l), Some(r)) => ctx.add(Expr::Concrete(l * r)),
-            (None, Some(0)) | (Some(0), None) => ctx.add(Expr::Concrete(0)),
-            (None, Some(1)) => self,
-            (Some(1), None) => other,
-            _ => {
-                // Sort the operands to canonicalize the expression
-                let (lhs, rhs) = if self < other {
-                    (self, other)
-                } else {
-                    (other, self)
-                };
-                ctx.add(Expr::Bin {
-                    op: ast::Op::Mul,
-                    lhs,
-                    rhs,
-                })
-            }
-        }
+        ctx.add(Expr::Bin {
+            op: ast::Op::Mul,
+            lhs: self,
+            rhs: other,
+        })
     }
 
     pub fn sub(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
-        if self == other {
-            return ctx.add(Expr::Concrete(0));
-        }
-        let l = self.as_concrete(ctx);
-        let r = other.as_concrete(ctx);
-
-        match (l, r) {
-            (Some(l), Some(r)) if l > r => ctx.add(Expr::Concrete(l - r)),
-            (None, Some(0)) => self,
-            _ => ctx.add(Expr::Bin {
-                op: ast::Op::Sub,
-                lhs: self,
-                rhs: other,
-            }),
-        }
+        ctx.add(Expr::Bin {
+            op: ast::Op::Sub,
+            lhs: self,
+            rhs: other,
+        })
     }
 
     pub fn div(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
-        if self == other {
-            return ctx.add(Expr::Concrete(1));
-        }
-
-        let l = self.as_concrete(ctx);
-        let r = other.as_concrete(ctx);
-
-        match (l, r) {
-            (Some(l), Some(r)) => ctx.add(Expr::Concrete(l / r)),
-            (None, Some(1)) => self,
-            _ => ctx.add(Expr::Bin {
-                op: ast::Op::Div,
-                lhs: self,
-                rhs: other,
-            }),
-        }
+        ctx.add(Expr::Bin {
+            op: ast::Op::Div,
+            lhs: self,
+            rhs: other,
+        })
     }
 
     pub fn rem(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
-        if self == other {
-            return ctx.add(Expr::Concrete(0));
-        }
-
-        let l = self.as_concrete(ctx);
-        let r = other.as_concrete(ctx);
-
-        match (l, r) {
-            (Some(l), Some(r)) => ctx.add(Expr::Concrete(l % r)),
-            (None, Some(1)) => ctx.add(Expr::Concrete(0)),
-            _ => ctx.add(Expr::Bin {
-                op: ast::Op::Mod,
-                lhs: self,
-                rhs: other,
-            }),
-        }
+        ctx.add(Expr::Bin {
+            op: ast::Op::Mod,
+            lhs: self,
+            rhs: other,
+        })
     }
 
     pub fn pow2(self, ctx: &mut impl Ctx<Expr>) -> Self {
-        let l = self.as_concrete(ctx);
-
-        match l {
-            Some(l) => ctx.add(Expr::Concrete(1 << l)),
-            _ => ctx.add(Expr::Fn {
-                op: ast::UnFn::Pow2,
-                args: Box::new([self]),
-            }),
-        }
+        ctx.add(Expr::Fn {
+            op: ast::UnFn::Pow2,
+            args: Box::new([self]),
+        })
     }
 
     pub fn log2(self, ctx: &mut impl Ctx<Expr>) -> Self {
-        let l = self.as_concrete(ctx);
-
-        match l {
-            Some(l) => ctx.add(Expr::Concrete(l.trailing_zeros() as u64)),
-            _ => ctx.add(Expr::Fn {
-                op: ast::UnFn::Log2,
-                args: Box::new([self]),
-            }),
-        }
+        ctx.add(Expr::Fn {
+            op: ast::UnFn::Log2,
+            args: Box::new([self]),
+        })
     }
 
     /// The proposition `self > other`

--- a/tests/ir_check/bundle-delay.expect
+++ b/tests/ir_check/bundle-delay.expect
@@ -26,7 +26,7 @@ error: bundle's availability is greater than the delay of the event
 6 │     bundle f[#P+1]: for<#k> @[G+#k, G+#P] 16;
   │                          -  ^^^^^^^^^^^^^ available for #P-#k cycles
   │                          │   
-  │                          takes values in [0, 1+#P)
+  │                          takes values in [0, #P+1)
 
 Compilation failed with 3 errors.
 Run with --show-models to generate assignments for failing constraints.

--- a/tests/ir_check/bundle-mismatch.expect
+++ b/tests/ir_check/bundle-mismatch.expect
@@ -29,10 +29,10 @@ error: source port does not provide value for as long as destination requires
   ┌─ tests/errors/bundle-mismatch.fil:9:28
   │
 2 │     in[#N]: for<#i> @[G+#i, G+#i+1] 32
-  │     -- requires value for @[T+1+#k, T+1+1+#k]
+  │     -- requires value for @[T+#k+1, T+#k+1+1]
   ·
 9 │     f1 := new Foo[#P]<T+1>(f{0..#P});
-  │                            ^^^^^^^^ source is available for @[T+#k, T+1+#k]
+  │                            ^^^^^^^^ source is available for @[T+#k, T+#k+1]
 
 Compilation failed with 4 errors.
 Run with --show-models to generate assignments for failing constraints.

--- a/tests/ir_check/bundle.expect
+++ b/tests/ir_check/bundle.expect
@@ -15,15 +15,15 @@ error: source port does not provide value for as long as destination requires
 10 │     f{1} = input;
    │     ----   ^^^^^ source is available for @[G, G+1]
    │     │       
-   │     requires value for @[G+1, G+1+1]
+   │     requires value for @[G+1, G+2]
 
 error: source port does not provide value for as long as destination requires
    ┌─ tests/errors/bundle.fil:13:17
    │
 13 │         f{#i} = d.out;
-   │         -----   ^^^^^ source is available for @[G+1+#i, G+2+#i]
+   │         -----   ^^^^^ source is available for @[G+#i+1, G+#i+2]
    │         │        
-   │         requires value for @[G+#i, G+1+#i]
+   │         requires value for @[G+#i, G+#i+1]
 
 error: out of bounds access of bundle
    ┌─ tests/errors/bundle.fil:15:11
@@ -38,9 +38,9 @@ error: source port does not provide value for as long as destination requires
    ┌─ tests/errors/bundle.fil:15:11
    │
 15 │     out = f{#N+1};
-   │     ----  ^^^^^^^ source is available for @[G+1+#N, G+1+1+#N]
+   │     ----  ^^^^^^^ source is available for @[G+#N+1, G+#N+1+1]
    │     │      
-   │     requires value for @[G+#N, G+1+#N]
+   │     requires value for @[G+#N, G+#N+1]
 
 Compilation failed with 5 errors.
 Run with --show-models to generate assignments for failing constraints.

--- a/tests/ir_check/poly-mismatch.expect
+++ b/tests/ir_check/poly-mismatch.expect
@@ -5,31 +5,31 @@ error: source port does not provide value for as long as destination requires
    ┌─ tests/errors/poly-mismatch.fil:12:28
    │
 12 │     a := new Add[#W]<G+#W>(s.out, acc);
-   │                            ^^^^^ source is available for @[G+#N, G+1+#N]
+   │                            ^^^^^ source is available for @[G+#N, G+#N+1]
    │
    ┌─ ./primitives/./comb.fil:9:13
    │
  9 │     @[G, L] left: #IN_WIDTH,
-   │             ---- requires value for @[G+#W, G+1+#W]
+   │             ---- requires value for @[G+#W, G+#W+1]
 
 error: source port does not provide value for as long as destination requires
    ┌─ tests/errors/poly-mismatch.fil:12:35
    │
 12 │     a := new Add[#W]<G+#W>(s.out, acc);
-   │                                   ^^^ source is available for @[G+#N, G+1+#N]
+   │                                   ^^^ source is available for @[G+#N, G+#N+1]
    │
    ┌─ ./primitives/./comb.fil:10:13
    │
 10 │     @[G, L] right: #IN_WIDTH,
-   │             ----- requires value for @[G+#W, G+1+#W]
+   │             ----- requires value for @[G+#W, G+#W+1]
 
 error: source port does not provide value for as long as destination requires
    ┌─ tests/errors/poly-mismatch.fil:13:11
    │
 13 │     out = a.out;
-   │     ----  ^^^^^ source is available for @[G+#W, G+1+#W]
+   │     ----  ^^^^^ source is available for @[G+#W, G+#W+1]
    │     │      
-   │     requires value for @[G+#N, G+1+#N]
+   │     requires value for @[G+#N, G+#N+1]
 
 error: source port does not provide value for as long as destination requires
    ┌─ tests/errors/poly-mismatch.fil:20:11


### PR DESCRIPTION
Moves basic simplification from the `ExprIdx` smart constructors into the `Ctx` `add` function instead.