### PR TITLE
Change info struct to use struct variants.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ topological-sort = "0.2"
 atty = "0.2"
 lazy_static = "1.4.0"
 easy-smt = "0.1.2"
+struct-variant = "1.0.2"
 
 calyx-ir = { version = "0.3.0" }
 calyx-frontend = { version = "0.3.0" }

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -97,6 +97,8 @@ pub struct Component {
     /// Externally facing interface information, used to preserve interface in compilation.
     /// Must be `Some` for toplevel components and externals.
     pub src_info: Option<InterfaceSrc>,
+    /// unannotated ports associated with this component
+    pub unannotated_ports: Box<Vec<(ast::Id, u64)>>,
 }
 
 impl Component {
@@ -271,17 +273,6 @@ impl Component {
         let mut acc = Vec::new();
         self.prop_params_acc(prop, &mut acc);
         acc
-    }
-
-    /// Unannotated Ports in the component
-    pub fn unannotated_ports(&self) -> Vec<(&ast::Id, u64)> {
-        self.info
-            .iter()
-            .filter_map(|(_, info)| match info {
-                Info::UnannotatedPort { name, width } => Some((name, *width)),
-                _ => None,
-            })
-            .collect()
     }
 }
 

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -482,14 +482,14 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
             self.port(port.inner().clone(), ir::PortOwner::sig_in());
         }
         for (name, width) in sig.unannotated_ports {
-            self.comp.add(ir::Info::unannotated_port(name, width));
+            self.comp.unannotated_ports.push((name, width));
         }
         // Constraints defined by the signature
         let mut cons = Vec::with_capacity(
             sig.param_constraints.len() + sig.event_constraints.len(),
         );
         for ec in sig.event_constraints {
-            let info = self.comp.add(ir::Info::assert(ir::Reason::misc(
+            let info = self.comp.add(ir::Info::assert(ir::info::Reason::misc(
                 "Signature assumption",
                 ec.pos(),
             )));
@@ -497,7 +497,7 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
             cons.extend(self.comp.assume(prop, info));
         }
         for pc in sig.param_constraints {
-            let info = self.comp.add(ir::Info::assert(ir::Reason::misc(
+            let info = self.comp.add(ir::Info::assert(ir::info::Reason::misc(
                 "Signature assumption",
                 pc.pos(),
             )));
@@ -522,9 +522,9 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
             .clone()
             .into_iter()
             .flat_map(|f| {
-                let reason = self
-                    .comp
-                    .add(ir::Reason::param_cons(comp_loc, f.pos()).into());
+                let reason = self.comp.add(
+                    ir::info::Reason::param_cons(comp_loc, f.pos()).into(),
+                );
                 let p = f.take().resolve_expr(&binding);
                 let prop = self.expr_cons(p);
                 // This is a checked fact because the calling component needs to
@@ -659,7 +659,8 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
             .into_iter()
             .flat_map(|ec| {
                 let reason = self.comp.add(
-                    ir::Reason::event_cons(instance.pos(), ec.pos()).into(),
+                    ir::info::Reason::event_cons(instance.pos(), ec.pos())
+                        .into(),
                 );
                 let ec = ec.take().resolve_event(&event_binding);
                 let prop = self.event_cons(ec);
@@ -769,7 +770,8 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
             ast::Command::Instance(inst) => self.instance(inst),
             ast::Command::Fact(ast::Fact { cons, checked }) => {
                 let reason = self.comp.add(
-                    ir::Reason::misc("source-level fact", cons.pos()).into(),
+                    ir::info::Reason::misc("source-level fact", cons.pos())
+                        .into(),
                 );
                 let prop = self.implication(cons.take());
                 let fact = if checked {
@@ -797,8 +799,11 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
                 let end = self.expr(end);
                 // Assumption that the index is within range
                 let reason = self.comp.add(
-                    ir::Reason::misc("loop index is within range", idx.pos())
-                        .into(),
+                    ir::info::Reason::misc(
+                        "loop index is within range",
+                        idx.pos(),
+                    )
+                    .into(),
                 );
 
                 // Compile the body in a new scope
@@ -849,8 +854,11 @@ impl<'ctx, 'prog> BuildCtx<'ctx, 'prog> {
             .collect_vec();
         // Add assumptions for range of bundle-bound indices
         let reason = self.comp.add(
-            ir::Reason::misc("bundle index is within range", GPosIdx::UNKNOWN)
-                .into(),
+            ir::info::Reason::misc(
+                "bundle index is within range",
+                GPosIdx::UNKNOWN,
+            )
+            .into(),
         );
         for (idx, len) in ports {
             let idx = idx.expr(self.comp);

--- a/src/ir/info.rs
+++ b/src/ir/info.rs
@@ -3,46 +3,61 @@ use crate::{ast, utils::GPosIdx};
 use codespan_reporting::diagnostic::Diagnostic;
 use struct_variant::struct_variant;
 
+/// An absence of information is still information
 pub struct Empty;
 
+/// Assertion information
 pub struct Assert(pub Reason);
 
+/// For [super::Param]
 pub struct Param {
+    /// Surface-level name of the parameter
     pub name: ast::Id,
     pub bind_loc: GPosIdx,
 }
 
+/// For [super::Event]
 pub struct Event {
+    /// Surface-level name of the event
     pub name: ast::Id,
     pub bind_loc: GPosIdx,
     pub delay_loc: GPosIdx,
+    /// interface port information
     pub interface_name: Option<ast::Id>,
     pub interface_bind_loc: Option<GPosIdx>,
 }
 
+/// For [super::EventBind]
 pub struct EventBind {
+    /// Location for the delay of the event
     pub ev_delay_loc: GPosIdx,
+    /// Location of the time expression provided as the binding
     pub bind_loc: GPosIdx,
 }
 
+/// For [super::Instance]
 pub struct Instance {
     pub name: ast::Id,
     pub comp_loc: GPosIdx,
     pub bind_loc: GPosIdx,
 }
 
+/// For [super::Invoke]
 pub struct Invoke {
     pub name: ast::Id,
     pub inst_loc: GPosIdx,
     pub bind_loc: GPosIdx,
 }
 
+/// For [super::Connect]
 pub struct Connect {
     pub dst_loc: GPosIdx,
     pub src_loc: GPosIdx,
 }
 
+/// For [super::Port]
 pub struct Port {
+    /// Surface-level name
     pub name: ast::Id,
     pub bind_loc: GPosIdx,
     pub width_loc: GPosIdx,
@@ -142,6 +157,13 @@ impl Info {
     }
 }
 
+/// Generates two functions for casting `Info` to a specific variant.
+///
+/// `as_{name}` returns `Some()` if the info is of the correct variant,
+/// `None` if the info was empty, and panics if the info was an incorrect variant.
+///
+/// Also defines a `From<&Info> for &{name}` implementation that panics if the info was not the right variant,
+/// and a `From<&Info> for Option<&{name}>` implementation that mirrors `as_{name}`.
 macro_rules! info_cast {
     ($class:tt, $name:ident) => {
         impl Info {

--- a/src/ir/info.rs
+++ b/src/ir/info.rs
@@ -146,10 +146,13 @@ macro_rules! info_cast {
     ($class:tt, $name:ident) => {
         impl Info {
             pub fn $name(&self) -> Option<&$class> {
-                if let Self::$class(v) = self {
-                    Some(v)
-                } else {
-                    None
+                match self {
+                    Self::$class(v) => Some(v),
+                    Self::Empty(_) => None,
+                    _ => unreachable!(
+                        "Incorrect info type for {}.",
+                        stringify!($class)
+                    ),
                 }
             }
         }

--- a/src/ir/info.rs
+++ b/src/ir/info.rs
@@ -154,8 +154,8 @@ macro_rules! info_cast {
             }
         }
 
-        impl From<Info> for $class {
-            fn from(info: Info) -> Self {
+        impl<'a> From<&'a Info> for &'a $class {
+            fn from(info: &'a Info) -> Self {
                 if let Info::$class(v) = info {
                     v
                 } else {
@@ -167,16 +167,9 @@ macro_rules! info_cast {
             }
         }
 
-        impl<'a> From<&'a Info> for &'a $class {
+        impl<'a> From<&'a Info> for Option<&'a $class> {
             fn from(info: &'a Info) -> Self {
-                if let Info::$class(v) = info {
-                    v
-                } else {
-                    unreachable!(
-                        "Incorrect info type for {}.",
-                        stringify!($class)
-                    );
-                }
+                info.$name()
             }
         }
     };

--- a/src/ir/info.rs
+++ b/src/ir/info.rs
@@ -162,8 +162,8 @@ impl Info {
 /// `as_{name}` returns `Some()` if the info is of the correct variant,
 /// `None` if the info was empty, and panics if the info was an incorrect variant.
 ///
-/// Also defines a `From<&Info> for &{name}` implementation that panics if the info was not the right variant,
-/// and a `From<&Info> for Option<&{name}>` implementation that mirrors `as_{name}`.
+/// Also defines a `From<&Info> for &{class}` implementation that panics if the info was not the right variant,
+/// and a `From<&Info> for Option<&{class}>` implementation that mirrors `as_{name}`.
 macro_rules! info_cast {
     ($class:tt, $name:ident) => {
         impl Info {

--- a/src/ir/info.rs
+++ b/src/ir/info.rs
@@ -1,76 +1,79 @@
 use super::{Component, DisplayCtx, ExprIdx, Range, TimeIdx, TimeSub};
 use crate::{ast, utils::GPosIdx};
 use codespan_reporting::diagnostic::Diagnostic;
+use struct_variant::struct_variant;
 
-#[derive(Default)]
+pub struct Empty;
+
+pub struct Assert(pub Reason);
+
+pub struct Param {
+    pub name: ast::Id,
+    pub bind_loc: GPosIdx,
+}
+
+pub struct Event {
+    pub name: ast::Id,
+    pub bind_loc: GPosIdx,
+    pub delay_loc: GPosIdx,
+    pub interface_name: Option<ast::Id>,
+    pub interface_bind_loc: Option<GPosIdx>,
+}
+
+pub struct EventBind {
+    pub ev_delay_loc: GPosIdx,
+    pub bind_loc: GPosIdx,
+}
+
+pub struct Instance {
+    pub name: ast::Id,
+    pub comp_loc: GPosIdx,
+    pub bind_loc: GPosIdx,
+}
+
+pub struct Invoke {
+    pub name: ast::Id,
+    pub inst_loc: GPosIdx,
+    pub bind_loc: GPosIdx,
+}
+
+pub struct Connect {
+    pub dst_loc: GPosIdx,
+    pub src_loc: GPosIdx,
+}
+
+pub struct Port {
+    pub name: ast::Id,
+    pub bind_loc: GPosIdx,
+    pub width_loc: GPosIdx,
+    pub live_loc: GPosIdx,
+}
+
 /// Information associated with the IR.
+#[struct_variant()]
 pub enum Info {
-    #[default]
-    /// An absence of information is still information
     Empty,
-    /// Assertion information
-    Assert(Reason),
-    /// For [super::Param]
-    Param {
-        /// Surface-level name of the parameter
-        name: ast::Id,
-        bind_loc: GPosIdx,
-    },
-    /// For [super::Event]
-    Event {
-        /// Surface-level name of the event
-        name: ast::Id,
-        bind_loc: GPosIdx,
-        delay_loc: GPosIdx,
-        /// interface port information
-        interface_name: Option<ast::Id>,
-        interface_bind_loc: Option<GPosIdx>,
-    },
-    /// For [super::EventBind]
-    EventBind {
-        /// Location for the delay of the event
-        ev_delay_loc: GPosIdx,
-        /// Location of the time expression provided as the binding
-        bind_loc: GPosIdx,
-    },
-    /// For [super::Instance]
-    Instance {
-        name: ast::Id,
-        comp_loc: GPosIdx,
-        bind_loc: GPosIdx,
-    },
-    /// For [super::Invoke]
-    Invoke {
-        name: ast::Id,
-        inst_loc: GPosIdx,
-        bind_loc: GPosIdx,
-    },
-    /// For [super::Connect]
-    Connect {
-        dst_loc: GPosIdx,
-        src_loc: GPosIdx,
-    },
-    /// For [super::Port]
-    Port {
-        /// Surface-level name
-        name: ast::Id,
-        bind_loc: GPosIdx,
-        width_loc: GPosIdx,
-        live_loc: GPosIdx,
-    },
-    UnannotatedPort {
-        name: ast::Id,
-        width: u64,
-    },
+    Assert,
+    Param,
+    Event,
+    EventBind,
+    Instance,
+    Invoke,
+    Connect,
+    Port,
 }
 
 impl Info {
+    pub fn empty() -> Self {
+        Self::Empty(Empty)
+    }
+
     pub fn assert(reason: Reason) -> Self {
-        Self::Assert(reason)
+        Assert(reason).into()
     }
 
     pub fn param(name: ast::Id, bind_loc: GPosIdx) -> Self {
-        Self::Param { name, bind_loc }
+        Param { name, bind_loc }.into()
     }
 
     pub fn event(
@@ -79,20 +82,22 @@ impl Info {
         delay_loc: GPosIdx,
         interface_port: Option<(ast::Id, GPosIdx)>,
     ) -> Self {
-        Self::Event {
+        Event {
             name,
             bind_loc,
             delay_loc,
             interface_name: interface_port.map(|(n, _)| n),
             interface_bind_loc: interface_port.map(|(_, l)| l),
         }
+        .into()
     }
 
     pub fn event_bind(ev_delay_loc: GPosIdx, bind_loc: GPosIdx) -> Self {
-        Self::EventBind {
+        EventBind {
             ev_delay_loc,
             bind_loc,
         }
+        .into()
     }
 
     pub fn instance(
@@ -100,23 +105,25 @@ impl Info {
         comp_loc: GPosIdx,
         bind_loc: GPosIdx,
     ) -> Self {
-        Self::Instance {
+        Instance {
             name,
             comp_loc,
             bind_loc,
         }
+        .into()
     }
 
     pub fn invoke(name: ast::Id, inst_loc: GPosIdx, bind_loc: GPosIdx) -> Info {
-        Self::Invoke {
+        Invoke {
             name,
             inst_loc,
             bind_loc,
         }
+        .into()
     }
 
     pub fn connect(dst_loc: GPosIdx, src_loc: GPosIdx) -> Self {
-        Self::Connect { dst_loc, src_loc }
+        Connect { dst_loc, src_loc }.into()
     }
 
     pub fn port(
@@ -125,18 +132,64 @@ impl Info {
         width_loc: GPosIdx,
         live_loc: GPosIdx,
     ) -> Self {
-        Self::Port {
+        Port {
             name,
             bind_loc,
             width_loc,
             live_loc,
         }
-    }
-
-    pub fn unannotated_port(name: ast::Id, width: u64) -> Self {
-        Self::UnannotatedPort { name, width }
+        .into()
     }
 }
+
+macro_rules! info_cast {
+    ($class:tt, $name:ident) => {
+        impl Info {
+            pub fn $name(&self) -> Option<&$class> {
+                if let Self::$class(v) = self {
+                    Some(v)
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl From<Info> for $class {
+            fn from(info: Info) -> Self {
+                if let Info::$class(v) = info {
+                    v
+                } else {
+                    unreachable!(
+                        "Incorrect info type for {}.",
+                        stringify!($class)
+                    );
+                }
+            }
+        }
+
+        impl<'a> From<&'a Info> for &'a $class {
+            fn from(info: &'a Info) -> Self {
+                if let Info::$class(v) = info {
+                    v
+                } else {
+                    unreachable!(
+                        "Incorrect info type for {}.",
+                        stringify!($class)
+                    );
+                }
+            }
+        }
+    };
+}
+
+info_cast!(Assert, as_assert);
+info_cast!(Param, as_param);
+info_cast!(Event, as_event);
+info_cast!(EventBind, as_event_bind);
+info_cast!(Instance, as_instance);
+info_cast!(Invoke, as_invoke);
+info_cast!(Connect, as_connect);
+info_cast!(Port, as_port);
 
 #[derive(Clone, PartialEq, Eq)]
 /// Why was an assertion created?
@@ -339,7 +392,7 @@ impl Reason {
 
 impl From<Reason> for Info {
     fn from(r: Reason) -> Self {
-        Self::Assert(r)
+        Self::assert(r)
     }
 }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -5,7 +5,7 @@ mod expr;
 mod fact;
 mod from_ast;
 mod idxs;
-mod info;
+pub mod info;
 mod printer;
 mod structure;
 mod subst;
@@ -23,7 +23,7 @@ pub use idxs::{
     CompIdx, EventIdx, ExprIdx, InfoIdx, InstIdx, InvIdx, ParamIdx, PortIdx,
     PropIdx, TimeIdx,
 };
-pub use info::{Info, Reason};
+pub use info::Info;
 pub use printer::{DisplayCtx, Printer};
 pub use structure::{
     Access, Direction, Event, Liveness, Param, ParamOwner, Port, PortOwner,

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -42,9 +42,7 @@ impl DisplayCtx<ir::Event> for ir::Component {
             format!("{idx}")
         } else {
             let ev = self.get(idx);
-            let ir::Info::Event { name, .. } = self.get(ev.info) else {
-                unreachable!("Expected event info")
-            };
+            let &ir::info::Event { ref name, .. } = self.get(ev.info).into();
             name.to_string()
         }
     }
@@ -55,10 +53,8 @@ impl DisplayCtx<ir::Param> for ir::Component {
         if log::log_enabled!(log::Level::Debug) {
             format!("{idx}")
         } else {
-            let param = self.get(idx);
-            let ir::Info::Param { name, .. } = self.get(param.info) else {
-                unreachable!("Expected param info");
-            };
+            let param: &ir::Param = self.get(idx);
+            let &ir::info::Param { ref name, .. } = self.get(param.info).into();
             format!("#{name}")
         }
     }
@@ -70,9 +66,7 @@ impl DisplayCtx<ir::Invoke> for ir::Component {
             format!("{idx}")
         } else {
             let inv = self.get(idx);
-            let ir::Info::Invoke { name, .. } = self.get(inv.info) else {
-                unreachable!("Expected invoke info");
-            };
+            let &ir::info::Invoke { ref name, .. } = self.get(inv.info).into();
             format!("{name}")
         }
     }
@@ -84,9 +78,8 @@ impl DisplayCtx<ir::Instance> for ir::Component {
             format!("{idx}")
         } else {
             let inst = self.get(idx);
-            let ir::Info::Instance { name, .. } = self.get(inst.info) else {
-                unreachable!("Expected instance info");
-            };
+            let &ir::info::Instance { ref name, .. } =
+                self.get(inst.info).into();
             format!("{name}")
         }
     }
@@ -95,9 +88,7 @@ impl DisplayCtx<ir::Instance> for ir::Component {
 impl DisplayCtx<ir::Port> for ir::Component {
     fn display(&self, idx: ir::PortIdx) -> String {
         let port = self.get(idx);
-        let ir::Info::Port { name, .. } = self.get(port.info) else {
-            unreachable!("Expected port info")
-        };
+        let &ir::info::Port { ref name, .. } = self.get(port.info).into();
         match port.owner {
             ir::PortOwner::Local | ir::PortOwner::Sig { .. } => {
                 name.to_string()
@@ -364,9 +355,7 @@ impl<'a> Printer<'a> {
         let param = self.ctx.get(idx);
         if !param.is_sig_owned() {
             let &ir::Param { info, .. } = c.get(idx);
-            let ir::Info::Param { name, .. } = c.get(info) else {
-                unreachable!("Expected param info");
-            };
+            let &ir::info::Param { name, .. } = c.get(info).into();
             writeln!(
                 f,
                 "{:indent$}{idx} = param {param}; // {name}",

--- a/src/ir_passes/discharge.rs
+++ b/src/ir_passes/discharge.rs
@@ -352,7 +352,7 @@ impl Visitor for Discharge {
         match self.check_valid(f.prop, comp) {
             None => {
                 let reason = comp.add(
-                    ir::Reason::misc(
+                    ir::info::Reason::misc(
                         "Discharged assumption",
                         utils::GPosIdx::UNKNOWN,
                     )
@@ -363,9 +363,7 @@ impl Visitor for Discharge {
                 )
             }
             Some(assign) => {
-                let ir::Info::Assert(reason) = comp.get(f.reason) else {
-                    unreachable!("expected assert reason")
-                };
+                let &ir::info::Assert(ref reason) = comp.get(f.reason).into();
                 let mut diag = reason.diag(comp);
                 if show_models {
                     diag = reason.diag(comp).with_notes(vec![format!(

--- a/src/ir_passes/lower/compile.rs
+++ b/src/ir_passes/lower/compile.rs
@@ -73,10 +73,10 @@ impl Compile {
             .map(|idx| Compile::port_def(ctx, comp, idx, &width_transform))
             .chain(
                 // adds unannotated ports to the list of ports
-                comp.unannotated_ports().into_iter().map(|(name, width)| {
+                comp.unannotated_ports.iter().map(|(name, width)| {
                     calyx::PortDef {
                         name: name.as_ref().into(),
-                        width: width_from_u64(width),
+                        width: width_from_u64(*width),
                         direction: calyx::Direction::Input,
                         attributes: calyx::Attributes::default(),
                     }


### PR DESCRIPTION
Adds struct variants to the info struct and defines conversion functions that panic when incorrect.

Requested from https://github.com/cucapra/filament/pull/238#discussion_r1276280429

This should probably be merged before #233 is worked on.