### PR TITLE
pass to build domination invariant

### DIFF
--- a/src/ir_passes/build_domination.rs
+++ b/src/ir_passes/build_domination.rs
@@ -1,0 +1,82 @@
+use crate::{
+    ir,
+    ir_visitor::{Action, Visitor},
+};
+
+#[derive(Default)]
+/// Rewrite the control program so that uses of ports and invocations
+/// dominated by their definitions.
+///
+/// Domination is achieved by hoisting all instances to the top of the scope
+/// followed by invocation and finally connections and other control operations.
+pub struct BuildDomination {
+    /// Instances in the current stack of scopes.
+    insts: Vec<Vec<ir::Command>>,
+    /// Invocations in the current stack of scopes.
+    invs: Vec<Vec<ir::Command>>,
+}
+
+impl BuildDomination {
+    /// Start a new scope.
+    fn start_scope(&mut self) {
+        self.insts.push(Vec::new());
+        self.invs.push(Vec::new());
+    }
+
+    /// End the current scope and return the instances and invocations
+    /// in the scope.
+    fn end_scope(&mut self) -> (Vec<ir::Command>, Vec<ir::Command>) {
+        let Some(insts) = self.insts.pop() else {
+            unreachable!("insts stack is empty")
+        };
+        let Some(invs) = self.invs.pop() else {
+            unreachable!("invs stack is empty")
+        };
+        (insts, invs)
+    }
+
+    fn add_inv(&mut self, inv: ir::InvIdx) {
+        self.invs.last_mut().unwrap().push(inv.into());
+    }
+
+    fn add_inst(&mut self, inst: ir::InstIdx) {
+        self.insts.last_mut().unwrap().push(inst.into());
+    }
+}
+
+impl Visitor for BuildDomination {
+    fn invoke(&mut self, inv: ir::InvIdx, _: &mut ir::Component) -> Action {
+        self.add_inv(inv);
+        // Remove the invocation
+        Action::Change(vec![])
+    }
+
+    fn instance(
+        &mut self,
+        inst: ir::InstIdx,
+        _comp: &mut ir::Component,
+    ) -> Action {
+        self.add_inst(inst);
+        // Remove the instance
+        Action::Change(vec![])
+    }
+
+    fn start_cmds(&mut self, _: &mut Vec<ir::Command>, _: &mut ir::Component) {
+        self.start_scope();
+    }
+
+    fn end_cmds(&mut self, cmds: &mut Vec<ir::Command>, _: &mut ir::Component) {
+        let (inst, invs) = self.end_scope();
+        // Insert instances and then invocations to the start of the scope.
+        *cmds = inst
+            .into_iter()
+            .chain(invs.into_iter())
+            .chain(cmds.drain(..))
+            .collect();
+    }
+
+    fn end(&mut self, _: &mut ir::Component) {
+        assert!(self.insts.is_empty());
+        assert!(self.invs.is_empty());
+    }
+}

--- a/src/ir_passes/mod.rs
+++ b/src/ir_passes/mod.rs
@@ -1,5 +1,6 @@
 mod assignment_check;
 mod assume;
+mod build_domination;
 mod bundle_elim;
 mod discharge;
 mod hoist_facts;
@@ -10,6 +11,7 @@ mod type_check;
 
 pub use assignment_check::AssignCheck;
 pub use assume::Assume;
+pub use build_domination::BuildDomination;
 pub use bundle_elim::BundleElim;
 pub use discharge::Discharge;
 pub use hoist_facts::HoistFacts;

--- a/src/ir_visitor/visitor.rs
+++ b/src/ir_visitor/visitor.rs
@@ -95,6 +95,7 @@ where
     ) -> Action {
         Action::Continue
     }
+
     /// Executed after the body of the loop is visited
     fn end_loop(
         &mut self,
@@ -158,6 +159,9 @@ where
     /// Perform action before visiting a sequence of commands which represent a scope.
     fn start_cmds(&mut self, _: &mut Vec<ir::Command>, _: &mut ir::Component) {}
 
+    /// Perform action after visiting a sequence of commands representing a scope.
+    fn end_cmds(&mut self, _: &mut Vec<ir::Command>, _: &mut ir::Component) {}
+
     fn visit_cmds(
         &mut self,
         cmds: &mut Vec<ir::Command>,
@@ -194,6 +198,7 @@ where
         if stopped {
             Action::Stop
         } else {
+            self.end_cmds(cmds, comp);
             Action::Continue
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ fn run(opts: &cmdline::Opts) -> Result<(), u64> {
 
     if opts.ir {
         let mut ir = ir::transform(ns);
+        ir_passes::BuildDomination::do_pass(opts, &mut ir)?;
         if opts.show_ir {
             ir::Printer::context(&ir, &mut std::io::stdout()).unwrap();
         }


### PR DESCRIPTION
Builds the domination invariant for the IR where instances are defined before invocations, which are defined before connections. Does this by hoisting all instances to the top of the scope followed by invocations. Everything else is left in place.