### PR TITLE
Limit uses of `as_concrete`

### DIFF
--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -38,6 +38,7 @@ impl Display for Expr {
 impl ExprIdx {
     #[inline]
     /// Attempts to convert this expression into a concrete value.
+    /// If the coercion should panic on failure, use [Self::concrete] instead.
     pub fn as_concrete(&self, comp: &Component) -> Option<u64> {
         if let Expr::Concrete(c) = comp.get(*self) {
             Some(*c)
@@ -48,14 +49,12 @@ impl ExprIdx {
 
     #[inline]
     /// Returns the concrete value represented by this expression or errors out.
-    pub fn concrete<Num>(&self, comp: &Component) -> Num
-    where
-        Num: From<u64>,
-    {
+    /// If an optional value is desired, use [Self::as_concrete] instead.
+    pub fn concrete(&self, comp: &Component) -> u64 {
         let Some(c) = self.as_concrete(comp) else {
             comp.internal_error(format!("{} is not a concrete number", self))
         };
-        Num::from(c)
+        c
     }
 
     /// Returns true if this expression is a constant.

--- a/src/ir/idxs.rs
+++ b/src/ir/idxs.rs
@@ -21,10 +21,7 @@ define_idx!(PortIdx, Port, "p");
 impl PortIdx {
     /// Return true if this port is definitely not a bundle.
     /// This is the case if we can statically prove that the port has a length of 1.
-    pub fn is_not_bundle<C>(&self, ctx: &C) -> bool
-    where
-        C: Ctx<Port> + Ctx<Expr>,
-    {
+    pub fn is_not_bundle<C>(&self, ctx: &Component) -> bool {
         let port = ctx.get(*self);
         port.live.len.is_const(ctx, 1)
     }

--- a/src/ir/printer.rs
+++ b/src/ir/printer.rs
@@ -27,10 +27,8 @@ impl DisplayCtx<ir::Prop> for ir::Component {
 impl DisplayCtx<ir::Time> for ir::Component {
     fn display(&self, idx: Idx<ir::Time>) -> String {
         let &ir::Time { event, offset } = self.get(idx);
-        if let Some(off) = offset.as_concrete(self) {
-            if off == 0 {
-                return self.display(event);
-            }
+        if offset.is_const(self, 0) {
+            return self.display(event);
         }
         format!("{}+{}", self.display(event), self.display(offset))
     }

--- a/src/ir_passes/assignment_check.rs
+++ b/src/ir_passes/assignment_check.rs
@@ -34,7 +34,7 @@ impl Visitor for AssignCheck {
                 continue;
             }
 
-            let len = port.live.len.as_concrete(comp).unwrap() as usize;
+            let len = port.live.len.concrete(comp) as usize;
 
             for i in 0..len {
                 self.ports.insert((idx, i), Vec::new());
@@ -47,8 +47,8 @@ impl Visitor for AssignCheck {
     fn connect(&mut self, con: &mut Connect, comp: &mut Component) -> Action {
         let Connect { dst, info, .. } = con;
 
-        let start = dst.start.as_concrete(comp).unwrap() as usize;
-        let end = dst.end.as_concrete(comp).unwrap() as usize;
+        let start = dst.start.concrete(comp) as usize;
+        let end = dst.end.concrete(comp) as usize;
 
         for i in start..end {
             self.ports

--- a/src/ir_passes/bundle_elim.rs
+++ b/src/ir_passes/bundle_elim.rs
@@ -26,8 +26,8 @@ impl BundleElim {
         let comp = ctx.get(cidx);
 
         let Access { port, start, end } = access;
-        let start = start.as_concrete(comp).unwrap() as usize;
-        let end = end.as_concrete(comp).unwrap() as usize;
+        let start = start.concrete(comp) as usize;
+        let end = end.concrete(comp) as usize;
 
         let mut ports = Vec::with_capacity(end - start);
 
@@ -58,7 +58,7 @@ impl BundleElim {
         let start = comp.get(range.start).clone();
         let end = comp.get(range.end).clone();
 
-        let len = len.as_concrete(comp).unwrap();
+        let len = len.concrete(comp);
 
         // if we need to preserve external interface information, we can't have bundle ports in the signature.
         if comp.src_info.is_some() && matches!(owner, PortOwner::Sig { .. }) {
@@ -233,12 +233,10 @@ impl BundleElim {
                 if comp.ports().is_valid(dst.port)
                     && comp.get(dst.port).is_local()
                 {
-                    let dst_start =
-                        dst.start.as_concrete(comp).unwrap() as usize;
-                    let dst_end = dst.end.as_concrete(comp).unwrap() as usize;
-                    let src_start =
-                        src.start.as_concrete(comp).unwrap() as usize;
-                    let src_end = src.end.as_concrete(comp).unwrap() as usize;
+                    let dst_start = dst.start.concrete(comp) as usize;
+                    let dst_end = dst.end.concrete(comp) as usize;
+                    let src_start = src.start.concrete(comp) as usize;
+                    let src_end = src.end.concrete(comp) as usize;
                     assert!(
                         dst_end - dst_start == src_end - src_start,
                         "Mismatched access lengths for connect `{}`",

--- a/src/ir_passes/lower/utils.rs
+++ b/src/ir_passes/lower/utils.rs
@@ -35,14 +35,6 @@ pub(super) fn interface_name(
     )
 }
 
-/// Compiles an [ExprIdx] into a [u64].
-/// Expects the [ExprIdx] to be a single constant value, and panics if this isn't the case
-pub(super) fn expr_u64(idx: ExprIdx, comp: &Component) -> u64 {
-    idx.as_concrete(comp).unwrap_or_else(|| {
-        comp.internal_error("Expression must be a constant.")
-    })
-}
-
 /// Converts an [ir::ExprIdx] into a [calyx::Width].
 /// Expects the [ir::ExprIdx] to either be a singular constant or an abstract variable.
 pub(super) fn expr_width(idx: ExprIdx, comp: &Component) -> calyx::Width {


### PR DESCRIPTION
A bunch of places in the code base use `as_concrete` and immediately unwrap it which leads to hard to read error messages. This instead defines a `concrete` method on `ExprIdx` that uses `internal_error` to signal better errors when problems occur.