### PR TITLE
Macro for pass pipeline specification

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -13,8 +13,8 @@ pub struct Opts {
     pub ir: bool,
 
     /// print out the IR
-    #[argh(switch, long = "show-ir")]
-    pub show_ir: bool,
+    #[argh(option, long = "dump-after")]
+    pub dump_after: Vec<String>,
 
     /// print out assignments that falsify the constraints
     #[argh(switch, long = "show-models")]

--- a/src/ir_passes/assignment_check.rs
+++ b/src/ir_passes/assignment_check.rs
@@ -22,6 +22,10 @@ pub struct AssignCheck {
 }
 
 impl Visitor for AssignCheck {
+    fn name() -> &'static str {
+        "assign-check"
+    }
+
     fn start(&mut self, comp: &mut Component) -> Action {
         // skip externals
         if comp.is_ext {

--- a/src/ir_passes/assume.rs
+++ b/src/ir_passes/assume.rs
@@ -118,6 +118,10 @@ impl Assume {
 }
 
 impl Visitor for Assume {
+    fn name() -> &'static str {
+        "add-assume"
+    }
+
     fn fact(&mut self, f: &mut ir::Fact, comp: &mut ir::Component) -> Action {
         if f.is_assume() {
             Action::AddBefore(

--- a/src/ir_passes/build_domination.rs
+++ b/src/ir_passes/build_domination.rs
@@ -45,6 +45,10 @@ impl BuildDomination {
 }
 
 impl Visitor for BuildDomination {
+    fn name() -> &'static str {
+        "build-domination"
+    }
+
     fn invoke(&mut self, inv: ir::InvIdx, _: &mut ir::Component) -> Action {
         self.add_inv(inv);
         // Remove the invocation

--- a/src/ir_passes/bundle_elim.rs
+++ b/src/ir_passes/bundle_elim.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-
-use itertools::Itertools;
-
 use crate::ir::{
     Access, Bind, Command, CompIdx, Component, Connect, Context, Ctx,
     DenseIndexInfo, Expr, Foreign, Info, InvIdx, Invoke, Liveness, MutCtx,
     Port, PortIdx, PortOwner, Printer, Range, Subst, Time,
 };
+use itertools::Itertools;
+use std::collections::HashMap;
 
 #[derive(Default)]
 // Eliminates bundle ports by breaking them into multiple len-1 ports, and eliminates local ports altogether.

--- a/src/ir_passes/discharge.rs
+++ b/src/ir_passes/discharge.rs
@@ -287,6 +287,10 @@ impl Discharge {
 }
 
 impl Visitor for Discharge {
+    fn name() -> &'static str {
+        "discharge"
+    }
+
     fn start(&mut self, comp: &mut ir::Component) -> Action {
         // Declare all parameters
         let int = self.sol.int_sort();

--- a/src/ir_passes/hoist_facts.rs
+++ b/src/ir_passes/hoist_facts.rs
@@ -44,6 +44,10 @@ impl HoistFacts {
 }
 
 impl Visitor for HoistFacts {
+    fn name() -> &'static str {
+        "hoist-facts"
+    }
+
     /// Collect all assumptions in a given scope and add them to the path condition.
     /// We do this so that all asserts in a scope are affected by all assumes.
     fn start_cmds(

--- a/src/ir_passes/interval_check.rs
+++ b/src/ir_passes/interval_check.rs
@@ -113,6 +113,10 @@ impl IntervalCheck {
 }
 
 impl Visitor for IntervalCheck {
+    fn name() -> &'static str {
+        "interval_check"
+    }
+
     fn start(&mut self, comp: &mut ir::Component) -> Action {
         // Ensure that delays are greater than zero
         let mut cmds: Vec<ir::Command> =

--- a/src/ir_passes/prop_simplify.rs
+++ b/src/ir_passes/prop_simplify.rs
@@ -181,7 +181,7 @@ impl Visitor for Simplify {
 
             let out = self.simplify_prop(prop, comp);
             if prop != out {
-                log::info!("{prop} ==> {out}");
+                log::debug!("{prop} ==> {out}");
             } else {
                 log::debug!("{prop} unchanged");
             }

--- a/src/ir_passes/prop_simplify.rs
+++ b/src/ir_passes/prop_simplify.rs
@@ -170,6 +170,10 @@ impl Simplify {
 }
 
 impl Visitor for Simplify {
+    fn name() -> &'static str {
+        "simplify"
+    }
+
     fn start(&mut self, comp: &mut ir::Component) -> Action {
         let old_len = comp.props().size();
         // Populate the prop_map with the simplified version of each proposition.

--- a/src/ir_passes/type_check.rs
+++ b/src/ir_passes/type_check.rs
@@ -53,6 +53,10 @@ impl TypeCheck {
 }
 
 impl Visitor for TypeCheck {
+    fn name() -> &'static str {
+        "type-check"
+    }
+
     fn connect(
         &mut self,
         c: &mut ir::Connect,

--- a/src/ir_visitor/visitor.rs
+++ b/src/ir_visitor/visitor.rs
@@ -52,6 +52,9 @@ pub trait Visitor
 where
     Self: Sized + Construct,
 {
+    /// The user visible name for the pass
+    fn name() -> &'static str;
+
     /// Executed after the visitor has visited all the components.
     /// If the return value is `Some`, the number is treated as an error code.
     fn after_traversal(&mut self) -> Option<u32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use filament::{
-    backend, binding, cmdline, ir, ir_passes,
-    ir_visitor::Visitor,
+    backend, binding, cmdline, ir, ir_passes as ip, log_time, pass_pipeline,
     passes::{self, Pass},
     resolver::Resolver,
     visitor::{Checker, Transform},
@@ -41,27 +40,25 @@ fn run(opts: &cmdline::Opts) -> Result<(), u64> {
 
     if opts.ir {
         let mut ir = ir::transform(ns);
-        ir_passes::BuildDomination::do_pass(opts, &mut ir)?;
-        if opts.show_ir {
-            ir::Printer::context(&ir, &mut std::io::stdout()).unwrap();
-        }
-        ir_passes::TypeCheck::do_pass(opts, &mut ir)?;
-        ir_passes::IntervalCheck::do_pass(opts, &mut ir)?;
-        ir_passes::Assume::do_pass(opts, &mut ir)?;
-        ir_passes::HoistFacts::do_pass(opts, &mut ir)?;
-        ir_passes::Simplify::do_pass(opts, &mut ir)?;
-        ir_passes::Discharge::do_pass(opts, &mut ir)?;
-        if opts.show_ir {
-            ir::Printer::context(&ir, &mut std::io::stdout()).unwrap();
+        pass_pipeline! {opts, ir;
+            ip::BuildDomination,
+            ip::TypeCheck,
+            ip::IntervalCheck,
+            ip::Assume,
+            ip::HoistFacts,
+            ip::Simplify,
+            ip::Discharge
         }
         // Return early if we're asked to dump the interface
         if opts.check {
             return Ok(());
         }
-        ir_passes::AssignCheck::do_pass(opts, &mut ir)?;
-        ir_passes::BundleElim::do_pass(&mut ir);
-        ir_passes::AssignCheck::do_pass(opts, &mut ir)?;
-        ir_passes::Compile::compile(ir);
+        // TODO(rachit): Once `BundleElim` implements `Visitor`, we can collapse this into
+        // one call to `pass_pipeline!`.
+        pass_pipeline! {opts, ir; ip::AssignCheck }
+        log_time!(ip::BundleElim::do_pass(&mut ir), "BundleElim");
+        pass_pipeline! {opts, ir; ip::AssignCheck }
+        log_time!(ip::Compile::compile(ir), "Compile");
         return Ok(());
     }
 

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -40,10 +40,11 @@ macro_rules! log_time {
 macro_rules! pass_pipeline {
     ($opts:ident, $ir:ident; $($pass:path),*) => {
         $(
-            $crate::log_time!(<$pass as $crate::ir_visitor::Visitor>::do_pass($opts, &mut $ir)?, stringify!($pass));
-            // if $opts.print_after.contains(stringify!($pass)) {
-            //     log::debug!("{ir}");
-            // }
+            let name = <$pass as $crate::ir_visitor::Visitor>::name();
+            $crate::log_time!(<$pass as $crate::ir_visitor::Visitor>::do_pass($opts, &mut $ir)?, name);
+            if $opts.dump_after.contains(&name.to_string()) {
+                $crate::ir::Printer::context(& $ir, &mut std::io::stdout()).unwrap()
+            }
         )*
     };
 }

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -1,0 +1,49 @@
+#[macro_export]
+/// Return the result of the computation and the time it took to run it.
+macro_rules! time {
+    ($e:expr) => {{
+        let t = std::time::Instant::now();
+        let r = $e;
+        (r, t.elapsed())
+    }};
+}
+
+#[macro_export]
+/// Logs the amount of time it took to run the expression.
+///
+macro_rules! log_time {
+    ($e:expr) => {{
+        let (r, t) = $crate::time!($e);
+        log::info!("{}: {}ms", stringify!($e), t.as_millis());
+        r
+    }};
+    // Variant to log the time with a custom message.
+    ($e:expr, $msg:expr) => {{
+        let (r, t) = $crate::time!($e);
+        log::info!("{}: {}ms", $msg, t.as_millis());
+        r
+    }};
+}
+
+#[macro_export]
+/// A macro generate the pass pipeline. For each provided pass, it will:
+/// 1. Record the amount of time it took to run the pass.
+/// 2. Print out the state of the AST if the name of the pass was in the
+///    print-after declaration.
+///
+/// Usage:
+/// ```
+/// pass_pipeline! { opts, ir;
+///   Pass1,
+///   Pass2, ...
+/// }
+macro_rules! pass_pipeline {
+    ($opts:ident, $ir:ident; $($pass:path),*) => {
+        $(
+            $crate::log_time!(<$pass as $crate::ir_visitor::Visitor>::do_pass($opts, &mut $ir)?, stringify!($pass));
+            // if $opts.print_after.contains(stringify!($pass)) {
+            //     log::debug!("{ir}");
+            // }
+        )*
+    };
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ mod bind_map;
 mod global_sym;
 mod gsym;
 mod idx;
+mod macros;
 mod namegenerator;
 mod obligation;
 mod position;


### PR DESCRIPTION
Adds a bunch of macros to clean up the pass specification process and replaces the `--show-ir` flag with `--dump-after` which allows us to control exactly which pass to print out information after. Additionally, the macro for pass specification tracks the amount of time each pass took at `--log info`.