### PR TITLE
Implement Ctx for Foreigns.

### DIFF
--- a/fil-derive/src/lib.rs
+++ b/fil-derive/src/lib.rs
@@ -10,16 +10,17 @@ use syn::{parse_macro_input, punctuated::Punctuated, DeriveInput};
 /// #[derive(Ctx)]
 /// struct Foo {
 ///     #[ctx(ir::Port)]
+///     #[add_ctx(ir::Port)]
 ///     foo: IndexStore<ir::Port>
 ///     #[mut_ctx(ir::Param)]
 ///     bar: IndexStore<ir::Param>
 /// }
 /// ```
 ///
-/// Note that the fields must already implement the `Ctx` and `MutCtx` traits
+/// Note that the fields must already implement the `Ctx`, `AddCtx`, and `MutCtx` traits
 /// for the two attributes.  The macro does not implement the trait for the
 /// structure itself, it simply delegates to the fields.
-#[proc_macro_derive(Ctx, attributes(ctx, mut_ctx))]
+#[proc_macro_derive(Ctx, attributes(ctx, add_ctx, mut_ctx))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let DeriveInput { ident, data, .. } = parse_macro_input!(input);
 
@@ -30,6 +31,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         }) => {
             let fields = fields.named.iter().flat_map(|field| {
                 let mut impl_ctx = None;
+                let mut impl_add_ctx = None;
                 let mut impl_mut_ctx = None;
                 for attr in &field.attrs {
                     // We expect the attribute to look like ctx(Type) and extract the type
@@ -38,13 +40,18 @@ pub fn derive(input: TokenStream) -> TokenStream {
                         assert!(nested.len() == 1);
                         impl_ctx = Some(nested[0].path().get_ident().unwrap().clone());
                     }
+                    if attr.path().is_ident("add_ctx") {
+                        let nested = attr.parse_args_with(Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated).unwrap();
+                        assert!(nested.len() == 1);
+                        impl_add_ctx = Some(nested[0].path().get_ident().unwrap().clone());
+                    }
                     if attr.path().is_ident("mut_ctx") {
                         let nested = attr.parse_args_with(Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated).unwrap();
                         assert!(nested.len() == 1);
                         impl_mut_ctx = Some(nested[0].path().get_ident().unwrap().clone());
                     }
                 }
-                if impl_ctx.is_none() && impl_mut_ctx.is_none() {
+                if impl_ctx.is_none() && impl_mut_ctx.is_none() && impl_add_ctx.is_none() {
                     return None;
                 }
 
@@ -53,15 +60,22 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 if let Some(typ) = impl_ctx {
                     let ctx = quote! {
                         impl Ctx<#typ> for #ident {
-                            fn add(&mut self, val: #typ) -> Idx<#typ> {
-                                Ctx::add(&mut self.#name, val)
-                            }
                             fn get(&self, idx: Idx<#typ>) -> &#typ {
                                 Ctx::get(&self.#name, idx)
                             }
                         }
                     };
                     out.extend(ctx);
+                }
+                if let Some(typ) = impl_add_ctx {
+                    let add_ctx = quote! {
+                        impl AddCtx<#typ> for #ident {
+                            fn add(&mut self, val: #typ) -> Idx<#typ> {
+                                AddCtx::add(&mut self.#name, val)
+                            }
+                        }
+                    };
+                    out.extend(add_ctx);
                 }
                 if let Some(typ) = impl_mut_ctx {
                     let mut_ctx = quote! {

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -1,4 +1,4 @@
-use super::{CompIdx, Component, Ctx, IndexStore, MutCtx};
+use super::{AddCtx, CompIdx, Component, Ctx, Foreign, IndexStore, MutCtx};
 use crate::utils::Idx;
 use fil_derive::Ctx;
 use std::collections::HashMap;
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 #[derive(Default, Ctx)]
 pub struct Context {
     #[ctx(Component)]
+    #[add_ctx(Component)]
     #[mut_ctx(Component)]
     pub comps: IndexStore<Component>,
     // Contains external components grouped by file name.
@@ -28,5 +29,16 @@ impl Context {
         self.externals.iter().find_map(|(filename, comps)| {
             comps.contains(&idx).then_some(filename.to_string())
         })
+    }
+}
+
+impl<T> Ctx<T, Foreign<T, Component>> for Context
+where
+    Component: Ctx<T>,
+{
+    fn get(&self, idx: Foreign<T, Component>) -> &T {
+        let (key, owner) = idx.take();
+
+        self.get(owner).get(key)
     }
 }

--- a/src/ir/ctx.rs
+++ b/src/ir/ctx.rs
@@ -1,21 +1,34 @@
 use super::Component;
-use crate::utils::Idx;
+use crate::utils::{Idx, IdxLike};
 
 /// A context for storing values with their indices.
-/// The context is indexed by [`Idx<T>`].
-pub trait Ctx<T> {
+/// The context is indexed by [`IdxLike<T>`].
+pub trait AddCtx<T, I = Idx<T>>
+where
+    I: IdxLike<T>,
+{
     /// Add a new value to the context
-    fn add(&mut self, val: T) -> Idx<T>;
-    /// Get the information associated with a value
-    fn get(&self, idx: Idx<T>) -> &T;
+    fn add(&mut self, val: T) -> I;
 }
 
-/// A context that provides mutable access to values using [`Idx<T>`] indices.
-pub trait MutCtx<T> {
+/// A that provides immutable access to values using [`IdxLike<T>`] indices.
+pub trait Ctx<T, I = Idx<T>>
+where
+    I: IdxLike<T>,
+{
+    /// Get the information associated with a value
+    fn get(&self, idx: I) -> &T;
+}
+
+/// A context that provides mutable access to values using [`IdxLike<T>`] indices.
+pub trait MutCtx<T, I = Idx<T>>
+where
+    I: IdxLike<T>,
+{
     /// Get a mutable reference to the value associated with the index.
-    fn get_mut(&mut self, idx: Idx<T>) -> &mut T;
+    fn get_mut(&mut self, idx: I) -> &mut T;
     /// Delete the value associated with the index.
-    fn delete(&mut self, idx: Idx<T>);
+    fn delete(&mut self, idx: I);
 }
 
 /// We can use indexing syntax for all values in the context for which it is a [`Ctx<K>`].

--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -62,7 +62,7 @@ impl ExprIdx {
     /// Returns true if this expression is a constant.
     /// Note that this process *does not* automatically reduce the expression.
     /// For example, `1 + 1` is not going to be reduced to `2`.
-    pub fn is_const(&self, ctx: &Component, n: u64) -> bool {
+    pub fn is_const(&self, ctx: &impl Ctx<Expr>, n: u64) -> bool {
         self.as_concrete(ctx).map(|c| c == n).unwrap_or(false)
     }
 
@@ -131,11 +131,10 @@ impl ExprIdx {
     }
 
     /// The proposition `self > other`
-    pub fn gt(
-        &self,
-        other: ExprIdx,
-        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
-    ) -> PropIdx {
+    pub fn gt<C>(&self, other: ExprIdx, ctx: &mut C) -> PropIdx
+    where
+        C: AddCtx<Prop> + Ctx<Expr>,
+    {
         if let (Some(l), Some(r)) =
             (self.as_concrete(ctx), other.as_concrete(ctx))
         {
@@ -153,11 +152,10 @@ impl ExprIdx {
         }
     }
 
-    pub fn gte(
-        &self,
-        other: ExprIdx,
-        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
-    ) -> PropIdx {
+    pub fn gte<C>(&self, other: ExprIdx, ctx: &mut C) -> PropIdx
+    where
+        C: AddCtx<Prop> + Ctx<Expr>,
+    {
         if let (Some(l), Some(r)) =
             (self.as_concrete(ctx), other.as_concrete(ctx))
         {
@@ -175,11 +173,10 @@ impl ExprIdx {
         }
     }
 
-    pub fn equal(
-        &self,
-        other: ExprIdx,
-        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
-    ) -> PropIdx {
+    pub fn equal<C>(&self, other: ExprIdx, ctx: &mut C) -> PropIdx
+    where
+        C: AddCtx<Prop> + Ctx<Expr>,
+    {
         if let (Some(l), Some(r)) =
             (self.as_concrete(ctx), other.as_concrete(ctx))
         {
@@ -199,19 +196,17 @@ impl ExprIdx {
         }
     }
 
-    pub fn lt(
-        self,
-        other: ExprIdx,
-        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
-    ) -> PropIdx {
+    pub fn lt<C>(self, other: ExprIdx, ctx: &mut C) -> PropIdx
+    where
+        C: AddCtx<Prop> + Ctx<Expr>,
+    {
         other.gt(self, ctx)
     }
 
-    pub fn lte(
-        self,
-        other: ExprIdx,
-        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
-    ) -> PropIdx {
+    pub fn lte<C>(self, other: ExprIdx, ctx: &mut C) -> PropIdx
+    where
+        C: AddCtx<Prop> + Ctx<Expr>,
+    {
         other.gte(self, ctx)
     }
 }

--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -1,4 +1,6 @@
-use super::{Cmp, CmpOp, Component, Ctx, ExprIdx, ParamIdx, Prop, PropIdx};
+use super::{
+    AddCtx, Cmp, CmpOp, Component, Ctx, ExprIdx, ParamIdx, Prop, PropIdx,
+};
 use crate::ast;
 use std::fmt::Display;
 
@@ -39,8 +41,8 @@ impl ExprIdx {
     #[inline]
     /// Attempts to convert this expression into a concrete value.
     /// If the coercion should panic on failure, use [Self::concrete] instead.
-    pub fn as_concrete(&self, comp: &Component) -> Option<u64> {
-        if let Expr::Concrete(c) = comp.get(*self) {
+    pub fn as_concrete(&self, ctx: &impl Ctx<Expr>) -> Option<u64> {
+        if let Expr::Concrete(c) = ctx.get(*self) {
             Some(*c)
         } else {
             None
@@ -74,7 +76,7 @@ impl ExprIdx {
     }
 
     /// Adds two expressions together.
-    pub fn add(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
+    pub fn add(self, other: ExprIdx, ctx: &mut impl AddCtx<Expr>) -> Self {
         ctx.add(Expr::Bin {
             op: ast::Op::Add,
             lhs: self,
@@ -82,7 +84,7 @@ impl ExprIdx {
         })
     }
 
-    pub fn mul(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
+    pub fn mul(self, other: ExprIdx, ctx: &mut impl AddCtx<Expr>) -> Self {
         ctx.add(Expr::Bin {
             op: ast::Op::Mul,
             lhs: self,
@@ -90,7 +92,7 @@ impl ExprIdx {
         })
     }
 
-    pub fn sub(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
+    pub fn sub(self, other: ExprIdx, ctx: &mut impl AddCtx<Expr>) -> Self {
         ctx.add(Expr::Bin {
             op: ast::Op::Sub,
             lhs: self,
@@ -98,7 +100,7 @@ impl ExprIdx {
         })
     }
 
-    pub fn div(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
+    pub fn div(self, other: ExprIdx, ctx: &mut impl AddCtx<Expr>) -> Self {
         ctx.add(Expr::Bin {
             op: ast::Op::Div,
             lhs: self,
@@ -106,7 +108,7 @@ impl ExprIdx {
         })
     }
 
-    pub fn rem(self, other: ExprIdx, ctx: &mut impl Ctx<Expr>) -> Self {
+    pub fn rem(self, other: ExprIdx, ctx: &mut impl AddCtx<Expr>) -> Self {
         ctx.add(Expr::Bin {
             op: ast::Op::Mod,
             lhs: self,
@@ -114,14 +116,14 @@ impl ExprIdx {
         })
     }
 
-    pub fn pow2(self, ctx: &mut impl Ctx<Expr>) -> Self {
+    pub fn pow2(self, ctx: &mut impl AddCtx<Expr>) -> Self {
         ctx.add(Expr::Fn {
             op: ast::UnFn::Pow2,
             args: vec![self],
         })
     }
 
-    pub fn log2(self, ctx: &mut impl Ctx<Expr>) -> Self {
+    pub fn log2(self, ctx: &mut impl AddCtx<Expr>) -> Self {
         ctx.add(Expr::Fn {
             op: ast::UnFn::Log2,
             args: vec![self],
@@ -129,7 +131,11 @@ impl ExprIdx {
     }
 
     /// The proposition `self > other`
-    pub fn gt(&self, other: ExprIdx, ctx: &mut Component) -> PropIdx {
+    pub fn gt(
+        &self,
+        other: ExprIdx,
+        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
+    ) -> PropIdx {
         if let (Some(l), Some(r)) =
             (self.as_concrete(ctx), other.as_concrete(ctx))
         {
@@ -147,7 +153,11 @@ impl ExprIdx {
         }
     }
 
-    pub fn gte(&self, other: ExprIdx, ctx: &mut Component) -> PropIdx {
+    pub fn gte(
+        &self,
+        other: ExprIdx,
+        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
+    ) -> PropIdx {
         if let (Some(l), Some(r)) =
             (self.as_concrete(ctx), other.as_concrete(ctx))
         {
@@ -165,7 +175,11 @@ impl ExprIdx {
         }
     }
 
-    pub fn equal(&self, other: ExprIdx, ctx: &mut Component) -> PropIdx {
+    pub fn equal(
+        &self,
+        other: ExprIdx,
+        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
+    ) -> PropIdx {
         if let (Some(l), Some(r)) =
             (self.as_concrete(ctx), other.as_concrete(ctx))
         {
@@ -185,11 +199,19 @@ impl ExprIdx {
         }
     }
 
-    pub fn lt(self, other: ExprIdx, ctx: &mut Component) -> PropIdx {
+    pub fn lt(
+        self,
+        other: ExprIdx,
+        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
+    ) -> PropIdx {
         other.gt(self, ctx)
     }
 
-    pub fn lte(self, other: ExprIdx, ctx: &mut Component) -> PropIdx {
+    pub fn lte(
+        self,
+        other: ExprIdx,
+        ctx: &mut (impl AddCtx<Prop> + Ctx<Expr>),
+    ) -> PropIdx {
         other.gte(self, ctx)
     }
 }

--- a/src/ir/fact.rs
+++ b/src/ir/fact.rs
@@ -1,4 +1,4 @@
-use super::{idxs::PropIdx, Ctx, ExprIdx, InfoIdx, TimeIdx, TimeSub};
+use super::{idxs::PropIdx, AddCtx, Ctx, ExprIdx, InfoIdx, TimeIdx, TimeSub};
 use std::fmt::{self, Display};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -136,21 +136,25 @@ impl PropIdx {
     }
 
     /// Negation of a proposition
-    pub fn not(self, ctx: &mut impl Ctx<Prop>) -> PropIdx {
+    pub fn not(self, ctx: &mut impl AddCtx<Prop>) -> PropIdx {
         ctx.add(Prop::Not(self))
     }
 
     /// Conjunction of two propositions
-    pub fn and(self, other: PropIdx, ctx: &mut impl Ctx<Prop>) -> PropIdx {
+    pub fn and(self, other: PropIdx, ctx: &mut impl AddCtx<Prop>) -> PropIdx {
         ctx.add(Prop::And(self, other))
     }
 
     /// Disjunction of two propositions
-    pub fn or(self, other: PropIdx, ctx: &mut impl Ctx<Prop>) -> PropIdx {
+    pub fn or(self, other: PropIdx, ctx: &mut impl AddCtx<Prop>) -> PropIdx {
         ctx.add(Prop::Or(self, other))
     }
 
-    pub fn implies(self, cons: PropIdx, ctx: &mut impl Ctx<Prop>) -> PropIdx {
+    pub fn implies(
+        self,
+        cons: PropIdx,
+        ctx: &mut impl AddCtx<Prop>,
+    ) -> PropIdx {
         ctx.add(Prop::Implies(self, cons))
     }
 }

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -5,8 +5,8 @@ use crate::ast::Id;
 use crate::diagnostics;
 use crate::errors::Error;
 use crate::ir::{
-    Cmp, Ctx, EventIdx, ExprIdx, InterfaceSrc, MutCtx, ParamIdx, PortIdx,
-    PropIdx, TimeIdx,
+    AddCtx, Cmp, Ctx, EventIdx, ExprIdx, InterfaceSrc, MutCtx, ParamIdx,
+    PortIdx, PropIdx, TimeIdx,
 };
 use crate::utils::{GPosIdx, Idx};
 use crate::{ast, ir, utils::Binding};

--- a/src/ir/idxs.rs
+++ b/src/ir/idxs.rs
@@ -21,7 +21,10 @@ define_idx!(PortIdx, Port, "p");
 impl PortIdx {
     /// Return true if this port is definitely not a bundle.
     /// This is the case if we can statically prove that the port has a length of 1.
-    pub fn is_not_bundle(&self, ctx: &Component) -> bool {
+    pub fn is_not_bundle<C>(&self, ctx: &C) -> bool
+    where
+        C: Ctx<Port> + Ctx<Expr>,
+    {
         let port = ctx.get(*self);
         port.live.len.is_const(ctx, 1)
     }

--- a/src/ir/idxs.rs
+++ b/src/ir/idxs.rs
@@ -1,13 +1,13 @@
 use super::{
-    Component, Ctx, Event, Expr, Info, Instance, Invoke, Param, Port, Prop,
-    Time,
+    AddCtx, Component, Ctx, Event, Expr, Info, Instance, Invoke, Param, Port,
+    Prop, Time,
 };
 use crate::define_idx;
 
 define_idx!(ParamIdx, Param, "pr");
 impl ParamIdx {
     /// Return an expression that refers to this parameter.
-    pub fn expr<C: Ctx<Expr>>(self, ctx: &mut C) -> ExprIdx {
+    pub fn expr<C: AddCtx<Expr>>(self, ctx: &mut C) -> ExprIdx {
         ctx.add(Expr::Param(self))
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -19,7 +19,7 @@ pub use context::Context;
 pub use control::{
     Command, Connect, EventBind, If, Instance, Invoke, Let, Loop,
 };
-pub use ctx::{Ctx, MutCtx};
+pub use ctx::{AddCtx, Ctx, MutCtx};
 pub use expr::Expr;
 pub use fact::{Cmp, CmpOp, Fact, Prop};
 pub use from_ast::astconv::transform;

--- a/src/ir/structure.rs
+++ b/src/ir/structure.rs
@@ -1,6 +1,6 @@
 use super::{
-    utils::Foreign, Bind, Component, Ctx, Expr, ExprIdx, Foldable, InfoIdx,
-    InvIdx, ParamIdx, PortIdx, Subst, TimeIdx, TimeSub,
+    utils::Foreign, AddCtx, Bind, Component, Ctx, Expr, ExprIdx, Foldable,
+    InfoIdx, InvIdx, ParamIdx, PortIdx, Subst, TimeIdx, TimeSub,
 };
 use crate::ast::Op;
 use std::fmt;
@@ -211,7 +211,7 @@ pub struct Access {
 impl Access {
     /// Construct an access on a simple port (i.e. not a bundle)
     /// The access only indexes into the first element of the port.
-    pub fn port(port: PortIdx, ctx: &mut impl Ctx<Expr>) -> Self {
+    pub fn port(port: PortIdx, ctx: &mut impl AddCtx<Expr>) -> Self {
         let zero = ctx.add(Expr::Concrete(0));
         let one = ctx.add(Expr::Concrete(1));
         Self {

--- a/src/ir/subst.rs
+++ b/src/ir/subst.rs
@@ -1,6 +1,6 @@
 use super::{
-    CmpOp, Component, Ctx, EventIdx, Expr, ExprIdx, ParamIdx, Prop, PropIdx,
-    Time, TimeIdx,
+    AddCtx, CmpOp, Component, Ctx, EventIdx, Expr, ExprIdx, ParamIdx, Prop,
+    PropIdx, Time, TimeIdx,
 };
 
 pub struct Bind<K: Eq, V>(Vec<(K, V)>);

--- a/src/ir/time.rs
+++ b/src/ir/time.rs
@@ -1,6 +1,6 @@
 use super::{
-    CmpOp, Component, Ctx, EventIdx, Expr, ExprIdx, Foldable, ParamIdx, Prop,
-    PropIdx, TimeIdx,
+    AddCtx, CmpOp, Component, Ctx, EventIdx, Expr, ExprIdx, Foldable, ParamIdx,
+    Prop, PropIdx, TimeIdx,
 };
 use std::fmt::{self, Display};
 
@@ -21,7 +21,7 @@ impl TimeIdx {
     /// Construct a [TimeSub] by subtracting two time expressions
     pub fn sub<C>(self, other: TimeIdx, ctx: &mut C) -> TimeSub
     where
-        C: Ctx<Time> + Ctx<Expr>,
+        C: Ctx<Time> + AddCtx<Expr>,
     {
         let l = ctx.get(self);
         let r = ctx.get(other);
@@ -39,28 +39,28 @@ impl TimeIdx {
 
     pub fn lte<C>(self, other: TimeIdx, ctx: &mut C) -> PropIdx
     where
-        C: Ctx<Time> + Ctx<Expr> + Ctx<Prop>,
+        C: AddCtx<Expr> + AddCtx<Prop>,
     {
         ctx.add(Prop::TimeCmp(CmpOp::lte(self, other)))
     }
 
     pub fn lt<C>(self, other: TimeIdx, ctx: &mut C) -> PropIdx
     where
-        C: Ctx<Time> + Ctx<Expr> + Ctx<Prop>,
+        C: AddCtx<Expr> + AddCtx<Prop>,
     {
         ctx.add(Prop::TimeCmp(CmpOp::lt(self, other)))
     }
 
     pub fn gt<C>(self, other: TimeIdx, ctx: &mut C) -> PropIdx
     where
-        C: Ctx<Time> + Ctx<Expr> + Ctx<Prop>,
+        C: AddCtx<Expr> + AddCtx<Prop>,
     {
         ctx.add(Prop::TimeCmp(CmpOp::gt(self, other)))
     }
 
     pub fn gte<C>(self, other: TimeIdx, ctx: &mut C) -> PropIdx
     where
-        C: Ctx<Time> + Ctx<Expr> + Ctx<Prop>,
+        C: AddCtx<Expr> + AddCtx<Prop>,
     {
         ctx.add(Prop::TimeCmp(CmpOp::gte(self, other)))
     }

--- a/src/ir/utils.rs
+++ b/src/ir/utils.rs
@@ -1,6 +1,6 @@
-use super::{Command, CompIdx, Context};
+use super::{AddCtx, Command, CompIdx, Context};
 use super::{Ctx, MutCtx};
-use crate::utils::{self, Idx};
+use crate::utils::{self, Idx, IdxLike};
 use bitvec::vec::BitVec;
 use itertools::Itertools;
 use std::{
@@ -30,12 +30,17 @@ impl<T> Ctx<T> for Interned<T>
 where
     T: Eq + std::hash::Hash,
 {
-    fn add(&mut self, val: T) -> Idx<T> {
-        self.intern(val)
-    }
-
     fn get(&self, idx: Idx<T>) -> &T {
         self.get(idx)
+    }
+}
+
+impl<T> AddCtx<T> for Interned<T>
+where
+    T: Eq + std::hash::Hash,
+{
+    fn add(&mut self, val: T) -> Idx<T> {
+        self.intern(val)
     }
 }
 
@@ -517,7 +522,6 @@ impl Traversal {
     }
 }
 
-#[derive(Copy)]
 /// A reference to a foreign key and its owner.
 /// On its own, a foreign key is not very useful. We need provide it with a context
 /// that can resolve the owner which can then resolve the underlying type.
@@ -578,6 +582,36 @@ where
     }
 }
 
+impl<T, C> IdxLike<T> for Foreign<T, C>
+where
+    C: Ctx<T>,
+{
+    const UNKNOWN: Self = Foreign {
+        key: Idx::UNKNOWN,
+        owner: Idx::UNKNOWN,
+    };
+
+    fn new(idx: usize) -> Self {
+        Self {
+            key: Idx::new(idx),
+            owner: Idx::UNKNOWN,
+        }
+    }
+
+    fn get(self) -> usize {
+        self.key.get()
+    }
+}
+
+impl<T, C> Ord for Foreign<T, C>
+where
+    C: Ctx<T>,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.owner.cmp(&other.owner).then(self.key.cmp(&other.key))
+    }
+}
+
 impl<T, C> Clone for Foreign<T, C>
 where
     C: Ctx<T>,
@@ -587,6 +621,18 @@ where
             key: self.key,
             owner: self.owner,
         }
+    }
+}
+
+/// All foreigns are [Copy]
+impl<T, C> Copy for Foreign<T, C> where C: Ctx<T> {}
+
+impl<T, C> PartialOrd for Foreign<T, C>
+where
+    C: Ctx<T>,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -612,12 +658,14 @@ where
 }
 
 impl<T> Ctx<T> for IndexStore<T> {
-    fn add(&mut self, val: T) -> Idx<T> {
-        self.add(val)
-    }
-
     fn get(&self, idx: Idx<T>) -> &T {
         self.get(idx)
+    }
+}
+
+impl<T> AddCtx<T> for IndexStore<T> {
+    fn add(&mut self, val: T) -> Idx<T> {
+        self.add(val)
     }
 }
 

--- a/src/ir_passes/assume.rs
+++ b/src/ir_passes/assume.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast,
-    ir::{self, Ctx, ExprIdx, PropIdx},
+    ir::{self, AddCtx, Ctx, ExprIdx, PropIdx},
     ir_visitor::{Action, Visitor, VisitorData},
 };
 

--- a/src/ir_passes/bundle_elim.rs
+++ b/src/ir_passes/bundle_elim.rs
@@ -1,7 +1,7 @@
 use crate::{
     cmdline,
     ir::{
-        Access, Bind, Command, Component, Connect, Context, Ctx,
+        Access, AddCtx, Bind, Command, Component, Connect, Context, Ctx,
         DenseIndexInfo, Expr, Foreign, Info, InvIdx, Invoke, Liveness, MutCtx,
         Port, PortIdx, PortOwner, Printer, Range, Subst, Time,
     },

--- a/src/ir_passes/hoist_facts.rs
+++ b/src/ir_passes/hoist_facts.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ir::{self, Ctx},
+    ir::{self, AddCtx},
     ir_visitor::{Action, Visitor, VisitorData},
 };
 

--- a/src/ir_passes/interval_check.rs
+++ b/src/ir_passes/interval_check.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 
-use crate::ir::{self, Ctx};
+use crate::ir::{self, AddCtx, Ctx};
 use crate::ir_visitor::{Action, Visitor, VisitorData};
 use crate::utils::GPosIdx;
 

--- a/src/ir_passes/mono/monodeferred.rs
+++ b/src/ir_passes/mono/monodeferred.rs
@@ -3,7 +3,7 @@ use super::{
     utils::{Base, Underlying},
     Monomorphize,
 };
-use crate::ir::{self, Ctx};
+use crate::ir::{self, AddCtx, Ctx};
 use itertools::Itertools;
 
 pub(super) struct MonoDeferred<'a, 'pass: 'a> {

--- a/src/ir_passes/mono/monosig.rs
+++ b/src/ir_passes/mono/monosig.rs
@@ -2,7 +2,7 @@ use super::{
     utils::{Base, Underlying},
     Monomorphize,
 };
-use crate::ir::{self, Ctx, DenseIndexInfo, Foreign, MutCtx};
+use crate::ir::{self, AddCtx, Ctx, DenseIndexInfo, Foreign, MutCtx};
 use itertools::Itertools;
 use std::collections::HashMap;
 

--- a/src/ir_passes/prop_simplify.rs
+++ b/src/ir_passes/prop_simplify.rs
@@ -62,10 +62,13 @@ impl Simplify {
         }
     }
 
-    fn prop_from_conjuncts(
+    fn prop_from_conjuncts<C>(
         conj: LinkedHashSet<ir::PropIdx>,
-        ctx: &mut (impl Ctx<ir::Prop> + AddCtx<ir::Prop>),
-    ) -> ir::PropIdx {
+        ctx: &mut C,
+    ) -> ir::PropIdx
+    where
+        C: Ctx<ir::Prop> + AddCtx<ir::Prop>,
+    {
         // Negative atoms we've already seen
         let mut neg = LinkedHashSet::new();
         let mut acc = ctx.add(ir::Prop::True);
@@ -87,10 +90,13 @@ impl Simplify {
         acc
     }
 
-    fn prop_from_disjuncts(
+    fn prop_from_disjuncts<C>(
         disj: LinkedHashSet<ir::PropIdx>,
-        ctx: &mut (impl Ctx<ir::Prop> + AddCtx<ir::Prop>),
-    ) -> ir::PropIdx {
+        ctx: &mut C,
+    ) -> ir::PropIdx
+    where
+        C: Ctx<ir::Prop> + AddCtx<ir::Prop>,
+    {
         // Negative atoms we've already seen
         let mut neg = LinkedHashSet::new();
         let mut acc = ctx.add(ir::Prop::False);

--- a/src/ir_passes/prop_simplify.rs
+++ b/src/ir_passes/prop_simplify.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ir::{self, Ctx},
+    ir::{self, AddCtx, Ctx},
     ir_visitor::{Action, Visitor, VisitorData},
 };
 use linked_hash_set::LinkedHashSet;
@@ -64,7 +64,7 @@ impl Simplify {
 
     fn prop_from_conjuncts(
         conj: LinkedHashSet<ir::PropIdx>,
-        ctx: &mut impl ir::Ctx<ir::Prop>,
+        ctx: &mut (impl Ctx<ir::Prop> + AddCtx<ir::Prop>),
     ) -> ir::PropIdx {
         // Negative atoms we've already seen
         let mut neg = LinkedHashSet::new();
@@ -89,7 +89,7 @@ impl Simplify {
 
     fn prop_from_disjuncts(
         disj: LinkedHashSet<ir::PropIdx>,
-        ctx: &mut impl ir::Ctx<ir::Prop>,
+        ctx: &mut (impl Ctx<ir::Prop> + AddCtx<ir::Prop>),
     ) -> ir::PropIdx {
         // Negative atoms we've already seen
         let mut neg = LinkedHashSet::new();

--- a/src/ir_passes/type_check.rs
+++ b/src/ir_passes/type_check.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ir::{self, Ctx},
+    ir::{self, AddCtx, Ctx},
     ir_visitor::{Action, Visitor, VisitorData},
     utils::GPosIdx,
 };


### PR DESCRIPTION
Fixes #261 and also generalizes some existing functions to use `Ctx` instead of `Component`