### PR TITLE
Don't parse constant ports

### DIFF
--- a/src/ast/control.rs
+++ b/src/ast/control.rs
@@ -35,17 +35,10 @@ impl From<Expr> for Access {
 pub enum Port {
     /// A port on this component
     This(Loc<Id>),
-    Constant(u64),
     /// A port on an invoke
-    InvPort {
-        invoke: Loc<Id>,
-        name: Loc<Id>,
-    },
+    InvPort { invoke: Loc<Id>, name: Loc<Id> },
     /// A port represented by an index into a bundle
-    Bundle {
-        name: Loc<Id>,
-        access: Loc<Access>,
-    },
+    Bundle { name: Loc<Id>, access: Loc<Access> },
     /// A bundle port on an invocation
     InvBundle {
         invoke: Loc<Id>,
@@ -61,10 +54,6 @@ impl Port {
 
     pub fn this(p: Loc<Id>) -> Self {
         Port::This(p)
-    }
-
-    pub fn constant(v: u64) -> Self {
-        Port::Constant(v)
     }
 
     pub fn bundle(name: Loc<Id>, access: Loc<Access>) -> Self {

--- a/src/ir/from_ast/astconv.rs
+++ b/src/ir/from_ast/astconv.rs
@@ -483,7 +483,6 @@ impl<'prog> BuildCtx<'prog> {
                 let (start, end) = self.access(access.take())?;
                 ir::Access { port, start, end }
             }
-            ast::Port::Constant(_) => todo!("Constant ports"),
         };
         Ok(acc)
     }


### PR DESCRIPTION
We don't support constant ports in the IR flow yet so let's not even parse them. Further changes to the frontend should bring them back.