### PR TITLE
Choose parameter SExp based on solver

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,7 +1,7 @@
 use argh::FromArgs;
 use std::{path::PathBuf, str::FromStr};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 /// Solver to use in the pass
 pub enum Solver {
     #[default]


### PR DESCRIPTION
Fixes #320. It seems like too much work to make the hack mentioned in the issue work because we would have to declare the sexpr in the easy_smt context. 

CVC5 authors said that this is a valid behavior of the solver so we're falling back on using the older parameter strings when using cvc5 (https://github.com/cvc5/cvc5/issues/9998).