### PR TITLE
Simplify aetherling module signatures

### DIFF
--- a/aetherling/conv2d_1/shim.fil
+++ b/aetherling/conv2d_1/shim.fil
@@ -44,11 +44,10 @@ comp Conv2d<'G: 1>(
 comp Conv2dWrapper<'G:1>(
     I[N]: ['G, 'G+1] 8
 ) -> (
-    O[N]: ['G+6, 'G+7] 8
+    O[N]: ['G+L, 'G+L+1] 8
 ) with {
-    // We assert the exact value here because otherwise the caller cannot pass data correctly.
-    exists L where L == 6;
-    exists N where N == 16;
+    exists N where N > 0, N <= 16, 16 % N == 0;
+    exists L where L > 0;
 } {
     C := new Conv2d<'G>(
         I{0}, I{1}, I{2}, I{3}, I{4}, I{5}, I{6}, I{7},

--- a/aetherling/conv2d_144/shim.fil
+++ b/aetherling/conv2d_144/shim.fil
@@ -9,15 +9,14 @@ comp Conv2d<'G: 9>(
 );
 }
 
-comp Conv2dWrapper<'G:9>(
-    I: ['G, 'G+6] 8
+comp Conv2dWrapper<'G:II>(
+    I: ['G, 'G+H] 8
 ) -> (
-    O: ['G+21, 'G+22] 8
+    O: ['G+L, 'G+L+1] 8
 ) with {
-    // We assert the exact value here because otherwise the caller cannot pass data correctly.
-    exists L where L == 21;
-    exists H where H == 6;
-    exists II where II == 9;
+    exists L where L > 0;
+    exists H where H > 0;
+    exists II where II > 0, II >= H;
 } {
     C := new Conv2d<'G>(I);
     O = C.O;

--- a/aetherling/conv2d_16/shim.fil
+++ b/aetherling/conv2d_16/shim.fil
@@ -14,9 +14,8 @@ comp Conv2dWrapper<'G:1>(
 ) -> (
     O[N]: ['G+L, 'G+L+1] 8
 ) with {
-    // We assert the exact value here because otherwise the caller cannot pass data correctly.
-    exists L where L == 7;
-    exists N where N == 1;
+    exists N where N > 0, N <= 16, 16 % N == 0;
+    exists L where L > 0;
 } {
     C := new Conv2d<'G>(I{0});
 

--- a/aetherling/conv2d_2/shim.fil
+++ b/aetherling/conv2d_2/shim.fil
@@ -26,11 +26,10 @@ comp Conv2d<'G: 1>(
 comp Conv2dWrapper<'G:1>(
     I[N]: ['G, 'G+1] 8
 ) -> (
-    O[N]: ['G+6, 'G+7] 8
+    O[N]: ['G+L, 'G+L+1] 8
 ) with {
-    // We assert the exact value here because otherwise the caller cannot pass data correctly.
-    exists L where L == 6;
-    exists N where N == 8;
+    exists N where N > 0, N <= 16, 16 % N == 0;
+    exists L where L > 0;
 } {
     C := new Conv2d<'G>(I{0}, I{1}, I{2}, I{3}, I{4}, I{5}, I{6}, I{7});
 

--- a/aetherling/conv2d_4/shim.fil
+++ b/aetherling/conv2d_4/shim.fil
@@ -20,11 +20,10 @@ comp Conv2d<'G: 1>(
 comp Conv2dWrapper<'G:1>(
     I[N]: ['G, 'G+1] 8
 ) -> (
-    O[N]: ['G+6, 'G+7] 8
+    O[N]: ['G+L, 'G+L+1] 8
 ) with {
-    // We assert the exact value here because otherwise the caller cannot pass data correctly.
-    exists L where L == 6;
-    exists N where N == 4;
+    exists N where N > 0, N <= 16, 16 % N == 0;
+    exists L where L > 0;
 } {
     C := new Conv2d<'G>(I{0}, I{1}, I{2}, I{3});
 

--- a/aetherling/conv2d_48/shim.fil
+++ b/aetherling/conv2d_48/shim.fil
@@ -10,15 +10,14 @@ comp Conv2d<'G: 3>(
 }
 
 
-comp Conv2dWrapper<'G:3>(
-    I: ['G, 'G+3] 8
+comp Conv2dWrapper<'G:II>(
+    I: ['G, 'G+H] 8
 ) -> (
-    O: ['G+12, 'G+13] 8
+    O: ['G+L, 'G+L+1] 8
 ) with {
-    // We assert the exact value here because otherwise the caller cannot pass data correctly.
-    exists L where L == 12;
-    exists H where H == 3;
-    exists II where II == 3;
+    exists L where L > 0;
+    exists H where H > 0;
+    exists II where II > 0, II >= H;
 } {
     C := new Conv2d<'G>(I);
     O = C.O;

--- a/aetherling/conv2d_8/shim.fil
+++ b/aetherling/conv2d_8/shim.fil
@@ -16,11 +16,10 @@ comp Conv2d<'G: 1>(
 comp Conv2dWrapper<'G:1>(
     I[N]: ['G, 'G+1] 8
 ) -> (
-    O[N]: ['G+6, 'G+7] 8
+    O[N]: ['G+L, 'G+L+1] 8
 ) with {
-    // We assert the exact value here because otherwise the caller cannot pass data correctly.
-    exists L where L == 6;
-    exists N where N == 2;
+    exists N where N > 0, N <= 16, 16 % N == 0;
+    exists L where L > 0;
 } {
     C := new Conv2d<'G>(I{0}, I{1});
 


### PR DESCRIPTION
The original implementations were asserting the exact values of the parameters which is unnecessary. 