### PR TITLE
Ensure constraints on invoke are asserted in the right scope

### DIFF
--- a/fil-ir/src/printer/comp.rs
+++ b/fil-ir/src/printer/comp.rs
@@ -122,6 +122,12 @@ impl<'a, 'b> Printer<'a, 'b> {
         }
     }
 
+    pub fn command_str(&self, c: &ir::Command) -> String {
+        let mut buf = Vec::new();
+        self.command(c, 0, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
     fn commands(
         &self,
         cmds: &[ir::Command],
@@ -185,7 +191,7 @@ impl<'a, 'b> Printer<'a, 'b> {
             })
             .join(",");
 
-        writeln!(f, "[{params}]]<{events}>(")?;
+        writeln!(f, "[{params}]<{events}>(")?;
 
         // Print input ports first. The direction is reversed when they are
         // bound in the body.

--- a/src/ir_passes/hoist_facts.rs
+++ b/src/ir_passes/hoist_facts.rs
@@ -63,7 +63,7 @@ impl Visitor for HoistFacts {
                 self.add_to_pc(prop);
             }
             _ => (),
-        })
+        });
     }
 
     fn fact(&mut self, fact: &mut ir::Fact, data: &mut VisitorData) -> Action {

--- a/src/ir_passes/interval_check.rs
+++ b/src/ir_passes/interval_check.rs
@@ -181,17 +181,18 @@ impl Visitor for IntervalCheck {
             let imp = assumes.implies(prop, comp);
             cmds.extend(comp.assert(imp, reason));
         }
+        Action::AddBefore(cmds)
+    }
 
-        // For each invoke, check the event bindings are well-formed
-        for idx in comp.invocations().idx_iter() {
-            // Clone here because we need to pass mutable ownership of the component
-            for eb in comp[idx].events.clone() {
-                if let Some(assert) = self.event_binding(eb, comp) {
-                    cmds.push(assert)
-                }
+    fn invoke(&mut self, idx: ir::InvIdx, data: &mut VisitorData) -> Action {
+        let comp = &mut data.comp;
+        let mut cmds = Vec::default();
+        // Clone here because we need to pass mutable ownership of the component
+        for eb in comp[idx].events.clone() {
+            if let Some(assert) = self.event_binding(eb, comp) {
+                cmds.push(assert)
             }
         }
-
         Action::AddBefore(cmds)
     }
 

--- a/tests/check/scope-invoke-check.expect
+++ b/tests/check/scope-invoke-check.expect
@@ -1,0 +1,2 @@
+---STDERR---
+[WARN ] Program has no entrypoint. Result will be empty.

--- a/tests/check/scope-invoke-check.fil
+++ b/tests/check/scope-invoke-check.fil
@@ -1,0 +1,10 @@
+comp Foo<'G:1>() -> () {}
+
+comp Bar[W, E, ?M=W-E-1]<'G: L>() -> () with {
+  exists L where L > 0;
+} {
+    if 1 == 1 {
+        f := new Foo<'G>();
+        exists L = 1;
+    }
+}

--- a/tests/check/scope-invoke-check.fil
+++ b/tests/check/scope-invoke-check.fil
@@ -1,10 +1,7 @@
-comp Foo<'G:1>() -> () {}
+comp Foo<'G:10>() -> () {}
 
-comp Bar[W, E, ?M=W-E-1]<'G: L>() -> () with {
-  exists L where L > 0;
-} {
-    if 1 == 1 {
+comp Bar[W]<'G: W>() -> () where W > 0 {
+    if W > 10 {
         f := new Foo<'G>();
-        exists L = 1;
     }
 }


### PR DESCRIPTION
Previously we were asserting facts about invoke arguments in the top-level scope which means that the path condition was not getting added correctly. This is problematic when we need to fundamentally rely on a particular assumption to make the check succeed.