### PR TITLE
Make `idx` in liveness optional in ports

### DIFF
--- a/fil-ir/src/from_ast/astconv.rs
+++ b/fil-ir/src/from_ast/astconv.rs
@@ -389,14 +389,9 @@ impl<'prog> BuildCtx<'prog> {
                 // The bundle type uses a fake bundle index and has a length of 1.
                 // We don't need to push a new scope because this type is does not
                 // bind any new parameters.
-                let p_name = self.gen_name();
                 let live = self.try_with_scope(|ctx| {
                     Ok(ir::Liveness {
-                        idx: ctx.param(
-                            p_name.into(),
-                            // Updated after the port is constructed
-                            ir::ParamOwner::bundle(ir::PortIdx::UNKNOWN),
-                        ), // This parameter is unused
+                        idx: None, // This parameter is unused
                         len: ctx.comp().num(1),
                         range: ctx.range(liveness.take())?,
                     })
@@ -428,11 +423,11 @@ impl<'prog> BuildCtx<'prog> {
                 // Construct the bundle type in a new scope.
                 let live = self.try_with_scope(|ctx| {
                     Ok(ir::Liveness {
-                        idx: ctx.param(
+                        idx: Some(ctx.param(
                             // Updated after the port is constructed
                             idx,
                             ir::ParamOwner::bundle(PortIdx::UNKNOWN),
-                        ),
+                        )),
                         len: ctx.expr(len.take())?,
                         range: ctx.range(liveness.take())?,
                     })
@@ -451,9 +446,10 @@ impl<'prog> BuildCtx<'prog> {
         let is_sig_port = p.is_sig();
         let idx = self.comp().add(p);
         // Fixup the liveness index parameter's owner
-        let p = self.comp().get(idx).live.idx;
-        let param = self.comp().get_mut(p);
-        param.owner = ir::ParamOwner::bundle(idx);
+        if let Some(p) = self.comp().get(idx).live.idx {
+            let param = self.comp().get_mut(p);
+            param.owner = ir::ParamOwner::bundle(idx);
+        }
 
         // If this is a signature port, try adding it to the component's external interface
         if is_sig_port {
@@ -958,6 +954,10 @@ impl<'prog> BuildCtx<'prog> {
         );
 
         for (idx, len) in ports {
+            let Some(idx) = idx else {
+                // If there is no parameter, we don't need assumptions
+                continue;
+            };
             let idx = idx.expr(self.comp());
             let start = idx.gte(self.comp().num(0), self.comp());
             let end = idx.lt(len, self.comp());

--- a/fil-ir/src/from_ast/build_ctx.rs
+++ b/fil-ir/src/from_ast/build_ctx.rs
@@ -110,9 +110,6 @@ pub(super) struct BuildCtx<'prog> {
     /// The parameter map returns instead of a [ir::ParamIdx] because let-bound
     /// parameters are immediately rewritten.
     param_map: ScopeMap<ir::ExprIdx, OwnedParam>,
-
-    /// Index for generating unique names
-    name_idx: u32,
 }
 
 impl<'prog> BuildCtx<'prog> {
@@ -121,7 +118,6 @@ impl<'prog> BuildCtx<'prog> {
             comp,
             sigs,
             diag: utils::Diagnostics::default(),
-            name_idx: 0,
             param_map: ScopeMap::new(),
             event_map: ScopeMap::new(),
             port_map: ScopeMap::new(),
@@ -145,13 +141,6 @@ impl<'prog> BuildCtx<'prog> {
     // takes the component from the builder
     pub fn take(self) -> ir::Component {
         self.comp
-    }
-
-    /// Generate a unique, new name for unused parameters
-    pub fn gen_name(&mut self) -> Id {
-        let name = format!("_{}", self.name_idx);
-        self.name_idx += 1;
-        Id::from(name)
     }
 
     /// Push a new scope level

--- a/fil-ir/src/info.rs
+++ b/fil-ir/src/info.rs
@@ -345,9 +345,8 @@ pub enum Reason {
         bundle_range_loc: GPosIdx,
         bundle_live: TimeSub,
         /// The bundle paramemter's binding location
-        param_loc: GPosIdx,
-        /// The start and end of index's range
-        param_range: (ExprIdx, ExprIdx),
+        param_info:
+            Option<(/*pos=*/ GPosIdx, /*range=*/ (ExprIdx, ExprIdx))>,
     },
     /// Well formed time interval
     WellFormedInterval {
@@ -383,15 +382,13 @@ impl Reason {
         event_delay_loc: GPosIdx,
         bundle_range_loc: GPosIdx,
         bundle_live: TimeSub,
-        param_loc: GPosIdx,
-        param_range: (ExprIdx, ExprIdx),
+        param_info: Option<(GPosIdx, (ExprIdx, ExprIdx))>,
     ) -> Self {
         Self::BundleDelay {
             event_delay_loc,
             bundle_range_loc,
             bundle_live,
-            param_loc,
-            param_range,
+            param_info,
         }
     }
 
@@ -640,8 +637,7 @@ impl Reason {
                 event_delay_loc,
                 bundle_range_loc,
                 bundle_live,
-                param_loc,
-                param_range,
+                param_info,
             } => {
                 let wire = bundle_range_loc.primary().with_message(format!(
                     "available for {} cycles",
@@ -652,13 +648,15 @@ impl Reason {
                 let mut labels = vec![wire, event];
 
                 // If the parameter location is not defined, we do not report its location
-                if let Some(loc) = param_loc.into_option() {
-                    let param = loc.secondary().with_message(format!(
-                        "takes values in [{}, {})",
-                        ctx.display(param_range.0),
-                        ctx.display(param_range.1)
-                    ));
-                    labels.push(param);
+                if let Some((param_loc, param_range)) = param_info {
+                    if let Some(loc) = param_loc.into_option() {
+                        let param = loc.secondary().with_message(format!(
+                            "takes values in [{}, {})",
+                            ctx.display(param_range.0),
+                            ctx.display(param_range.1)
+                        ));
+                        labels.push(param);
+                    }
                 }
 
                 Diagnostic::error()

--- a/fil-ir/src/printer/display_ctx.rs
+++ b/fil-ir/src/printer/display_ctx.rs
@@ -156,7 +156,11 @@ impl<'a> DisplayCtx<&'a ir::Liveness> for ir::Component {
         write!(
             f,
             "for<{}: {}> {}",
-            self.display(*idx),
+            if let Some(idx) = idx {
+                self.display(*idx)
+            } else {
+                "_".to_string()
+            },
             self.display(*len),
             self.display(range)
         )

--- a/fil-ir/src/validate.rs
+++ b/fil-ir/src/validate.rs
@@ -63,8 +63,11 @@ impl<'a> Validate<'a> {
     fn port(&self, pidx: ir::PortIdx) {
         let ir::Port { owner, live, .. } = self.comp.get(pidx);
         // check (1)
-        let ir::Liveness { idx: par_idx, .. } = live;
-        match self.comp.get(*par_idx).owner {
+        if let ir::Liveness {
+            idx: Some(par_idx), ..
+        } = live
+        {
+            match self.comp.get(*par_idx).owner {
             ir::ParamOwner::Sig => self.comp.internal_error(format!(
                 "{} should be owned by a bundle but is owned by a sig",
                 self.comp.display(*par_idx)
@@ -88,6 +91,7 @@ impl<'a> Validate<'a> {
                         format!("{par_idx} should be owned by {pidx} but is owned by {port_idx}"))
                 }
             }
+        }
         }
 
         // check (2)

--- a/src/ir_passes/bundle_elim.rs
+++ b/src/ir_passes/bundle_elim.rs
@@ -54,7 +54,6 @@ impl BundleElim {
 
         let start = comp.get(range.start).clone();
         let end = comp.get(range.end).clone();
-
         let len = len.concrete(comp);
 
         // if we need to preserve external interface information, we can't have bundle ports in the signature.
@@ -74,28 +73,34 @@ impl BundleElim {
         // create a single port for each element in the bundle.
         let ports = (0..len)
             .map(|i| {
-                // binds the index parameter to the current bundle index
-                let binding: Bind<_, _> =
-                    Bind::new([(idx, comp.add(Expr::Concrete(i)))]);
+                let range = if let Some(idx) = idx {
+                    // binds the index parameter to the current bundle index
+                    let binding: Bind<ir::ParamIdx, _> =
+                        Bind::new([(idx, comp.add(Expr::Concrete(i)))]);
 
-                // calculates the offsets based on this binding and generates new start and end times.
-                let offset = Subst::new(start.offset, &binding).apply(comp);
-                let start = comp.add(Time {
-                    event: start.event,
-                    offset,
-                });
+                    // calculates the offsets based on this binding and generates new start and end times.
+                    let offset = Subst::new(start.offset, &binding).apply(comp);
+                    let start = comp.add(Time {
+                        event: start.event,
+                        offset,
+                    });
 
-                let offset = Subst::new(end.offset, &binding).apply(comp);
-                let end = comp.add(Time {
-                    event: end.event,
-                    offset,
-                });
+                    let offset = Subst::new(end.offset, &binding).apply(comp);
+                    let end = comp.add(Time {
+                        event: end.event,
+                        offset,
+                    });
+
+                    Range { start, end }
+                } else {
+                    range.clone()
+                };
 
                 // creates a new liveness with the new start and end times and length one
                 let live = Liveness {
-                    idx, // this should technically be some null parameter, as it will refer to a deleted parameter now.
+                    idx: None,
                     len: one,
-                    range: Range { start, end },
+                    range,
                 };
 
                 // creates a new portowner based on the original owner
@@ -133,7 +138,9 @@ impl BundleElim {
         // delete the original port
         comp.delete(pidx);
         // delete the corresponding parameter
-        comp.delete(idx);
+        if let Some(idx) = idx {
+            comp.delete(idx);
+        }
         ports
     }
 

--- a/src/ir_passes/interval_check.rs
+++ b/src/ir_passes/interval_check.rs
@@ -60,7 +60,15 @@ impl IntervalCheck {
 
     /// Proposition that ensures that the given parameter is in range
     fn in_range(live: &ir::Liveness, comp: &mut ir::Component) -> ir::PropIdx {
-        let &ir::Liveness { idx, len, .. } = live;
+        let &ir::Liveness {
+            idx: Some(idx),
+            len,
+            ..
+        } = live
+        else {
+            // If there is no index, then we don't need to assert its range.
+            return comp.add(ir::Prop::True);
+        };
         let zero = comp.num(0);
         let idx = idx.expr(comp);
         let lo = idx.gte(zero, comp);
@@ -163,16 +171,19 @@ impl Visitor for IntervalCheck {
             let ev = &comp[st_ev];
             let delay = ev.delay.clone();
             let &ir::info::Event { delay_loc, .. } = comp.get(ev.info).into();
-            let param = comp.get(live.idx);
-            let &ir::info::Param { bind_loc, .. } = comp.get(param.info).into();
-            let zero = comp.num(0);
+            let param_info = live.idx.map(|idx| {
+                let param = comp.get(idx);
+                let &ir::info::Param { bind_loc, .. } =
+                    comp.get(param.info).into();
+                let zero = comp.num(0);
+                (bind_loc, (zero, live.len))
+            });
             let reason = comp.add(
                 ir::info::Reason::bundle_delay(
                     delay_loc,
                     live_loc,
                     len.clone(),
-                    bind_loc,
-                    (zero, live.len),
+                    param_info,
                 )
                 .into(),
             );
@@ -208,11 +219,15 @@ impl Visitor for IntervalCheck {
         let in_range = Self::in_range(&dst_t, comp)
             .and(Self::in_range(&src_t, comp), comp);
 
-        // Substitute the parameter used in source with that in dst
-        let binding = vec![(dst_t.idx, src_t.idx.expr(comp))];
         let dst_range =
-            ir::Subst::new(dst_t.range.clone(), &ir::Bind::new(binding))
-                .apply(comp);
+            if let (Some(dst_idx), Some(src_idx)) = (dst_t.idx, src_t.idx) {
+                let binding = vec![(dst_idx, src_idx.expr(comp))];
+                ir::Subst::new(dst_t.range.clone(), &ir::Bind::new(binding))
+                    .apply(comp)
+            } else {
+                // If either liveness is not indexed, then we can't do the substituion
+                dst_t.range.clone()
+            };
 
         // Assuming that lengths are equal
         let pre_req = src_t.len.equal(dst_t.len, comp).and(in_range, comp);

--- a/src/ir_passes/mono/monosig.rs
+++ b/src/ir_passes/mono/monosig.rs
@@ -712,9 +712,10 @@ impl MonoSig {
 
         let ir::Liveness { idx, len, range } = live;
 
-        let mono_liveness_idx = self
-            .bundle_param(underlying, pass, idx.ul(), new_port)
-            .get();
+        let mono_liveness_idx = idx.map(|idx| {
+            self.bundle_param(underlying, pass, idx.ul(), new_port)
+                .get()
+        });
 
         let mut mono_liveness = ir::Liveness {
             idx: mono_liveness_idx,
@@ -856,16 +857,19 @@ impl MonoSig {
 
         let ir::Liveness { idx, len, range } = live;
 
-        let mono_liveness_idx =
-            self.bundle_param(underlying, pass, idx.ul(), new_port);
+        let mono_liveness_idx = idx
+            .map(|idx| self.bundle_param(underlying, pass, idx.ul(), new_port));
 
         let mut mono_liveness = ir::Liveness {
-            idx: mono_liveness_idx.get(),
+            idx: mono_liveness_idx.map(|idx| idx.get()),
             len: *len,            // placeholder
             range: range.clone(), // placeholder
         };
 
-        self.bundle_param_map.insert(new_port, mono_liveness_idx);
+        if let Some(m_idx) = mono_liveness_idx {
+            self.bundle_param_map.insert(new_port, m_idx);
+        }
+
         let mono_width = self.expr(underlying, width.ul());
         mono_liveness.len = self.expr(underlying, mono_liveness.len.ul()).get();
         mono_liveness.len = self


### PR DESCRIPTION
The `idx` field was previously always required for `Liveness` which added a lot of unused parameters and assumptions for those parameters. This makes the `idx` field optional which does make the code less clean but I think is overall worth it.