### PR TITLE
Remove unused parameters generated for bundles

### DIFF
--- a/fil-ast/src/control.rs
+++ b/fil-ast/src/control.rs
@@ -288,7 +288,7 @@ impl If {
 /// ```
 pub struct BundleType {
     /// The name of the parameter for the bundle type
-    pub idx: Loc<Id>,
+    pub idx: Option<Loc<Id>>,
     /// Length of the bundle. The index parameter ranges over [0, len)
     pub len: Loc<Expr>,
     /// Availability interval for the bundle
@@ -299,7 +299,7 @@ pub struct BundleType {
 
 impl BundleType {
     pub fn new(
-        idx: Loc<Id>,
+        idx: Option<Loc<Id>>,
         len: Loc<Expr>,
         liveness: Loc<Range>,
         bitwidth: Loc<Expr>,

--- a/fil-ast/src/parser.rs
+++ b/fil-ast/src/parser.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::type_complexity)]
 
 //! Parser for Filament programs.
 use crate::{self as ast, Loc, TimeSub};
@@ -357,7 +358,6 @@ impl FilamentParser {
         Ok(evs)
     }
 
-    #[allow(clippy::type_complexity)]
     fn ports(
         input: Node,
     ) -> ParseResult<(Ports, Vec<ast::InterfaceDef>, Vec<(ast::Id, u64)>)> {

--- a/fil-ast/src/parser.rs
+++ b/fil-ast/src/parser.rs
@@ -707,11 +707,12 @@ impl FilamentParser {
 
     fn bundle_typ(
         input: Node,
-    ) -> ParseResult<(Loc<ast::Id>, Loc<ast::Range>, Loc<ast::Expr>)> {
+    ) -> ParseResult<(Option<Loc<ast::Id>>, Loc<ast::Range>, Loc<ast::Expr>)>
+    {
         Ok(match_nodes!(
             input.into_children();
-            [param_var(param), interval_range(range), expr(width)] => (param, range, width),
-            [interval_range(range), expr(width)] => (Loc::unknown(ast::Id::from("_")), range, width),
+            [param_var(param), interval_range(range), expr(width)] => (Some(param), range, width),
+            [interval_range(range), expr(width)] => (None, range, width),
         ))
     }
 

--- a/fil-ir/src/from_ast/astconv.rs
+++ b/fil-ir/src/from_ast/astconv.rs
@@ -391,7 +391,7 @@ impl<'prog> BuildCtx<'prog> {
                 // bind any new parameters.
                 let live = self.try_with_scope(|ctx| {
                     Ok(ir::Liveness {
-                        idx: None, // This parameter is unused
+                        idx: None,
                         len: ctx.comp().num(1),
                         range: ctx.range(liveness.take())?,
                     })
@@ -423,11 +423,13 @@ impl<'prog> BuildCtx<'prog> {
                 // Construct the bundle type in a new scope.
                 let live = self.try_with_scope(|ctx| {
                     Ok(ir::Liveness {
-                        idx: Some(ctx.param(
-                            // Updated after the port is constructed
-                            idx,
-                            ir::ParamOwner::bundle(PortIdx::UNKNOWN),
-                        )),
+                        idx: idx.map(|idx| {
+                            ctx.param(
+                                idx,
+                                // Updated after the port is constructed
+                                ir::ParamOwner::bundle(PortIdx::UNKNOWN),
+                            )
+                        }),
                         len: ctx.expr(len.take())?,
                         range: ctx.range(liveness.take())?,
                     })


### PR DESCRIPTION
Follow up to #359 which make `idx` field in the IR an optional. We were still generating unused parameters because the AST would preemptively generate parameters for bundles when they were missing.