### PR TITLE
Revert "Make `idx` in liveness optional in ports (#359)"

### DIFF
--- a/fil-ir/src/from_ast/build_ctx.rs
+++ b/fil-ir/src/from_ast/build_ctx.rs
@@ -110,6 +110,9 @@ pub(super) struct BuildCtx<'prog> {
     /// The parameter map returns instead of a [ir::ParamIdx] because let-bound
     /// parameters are immediately rewritten.
     param_map: ScopeMap<ir::ExprIdx, OwnedParam>,
+
+    /// Index for generating unique names
+    name_idx: u32,
 }
 
 impl<'prog> BuildCtx<'prog> {
@@ -118,6 +121,7 @@ impl<'prog> BuildCtx<'prog> {
             comp,
             sigs,
             diag: utils::Diagnostics::default(),
+            name_idx: 0,
             param_map: ScopeMap::new(),
             event_map: ScopeMap::new(),
             port_map: ScopeMap::new(),
@@ -141,6 +145,13 @@ impl<'prog> BuildCtx<'prog> {
     // takes the component from the builder
     pub fn take(self) -> ir::Component {
         self.comp
+    }
+
+    /// Generate a unique, new name for unused parameters
+    pub fn gen_name(&mut self) -> Id {
+        let name = format!("_{}", self.name_idx);
+        self.name_idx += 1;
+        Id::from(name)
     }
 
     /// Push a new scope level

--- a/fil-ir/src/info.rs
+++ b/fil-ir/src/info.rs
@@ -345,8 +345,9 @@ pub enum Reason {
         bundle_range_loc: GPosIdx,
         bundle_live: TimeSub,
         /// The bundle paramemter's binding location
-        param_info:
-            Option<(/*pos=*/ GPosIdx, /*range=*/ (ExprIdx, ExprIdx))>,
+        param_loc: GPosIdx,
+        /// The start and end of index's range
+        param_range: (ExprIdx, ExprIdx),
     },
     /// Well formed time interval
     WellFormedInterval {
@@ -382,13 +383,15 @@ impl Reason {
         event_delay_loc: GPosIdx,
         bundle_range_loc: GPosIdx,
         bundle_live: TimeSub,
-        param_info: Option<(GPosIdx, (ExprIdx, ExprIdx))>,
+        param_loc: GPosIdx,
+        param_range: (ExprIdx, ExprIdx),
     ) -> Self {
         Self::BundleDelay {
             event_delay_loc,
             bundle_range_loc,
             bundle_live,
-            param_info,
+            param_loc,
+            param_range,
         }
     }
 
@@ -637,7 +640,8 @@ impl Reason {
                 event_delay_loc,
                 bundle_range_loc,
                 bundle_live,
-                param_info,
+                param_loc,
+                param_range,
             } => {
                 let wire = bundle_range_loc.primary().with_message(format!(
                     "available for {} cycles",
@@ -648,15 +652,13 @@ impl Reason {
                 let mut labels = vec![wire, event];
 
                 // If the parameter location is not defined, we do not report its location
-                if let Some((param_loc, param_range)) = param_info {
-                    if let Some(loc) = param_loc.into_option() {
-                        let param = loc.secondary().with_message(format!(
-                            "takes values in [{}, {})",
-                            ctx.display(param_range.0),
-                            ctx.display(param_range.1)
-                        ));
-                        labels.push(param);
-                    }
+                if let Some(loc) = param_loc.into_option() {
+                    let param = loc.secondary().with_message(format!(
+                        "takes values in [{}, {})",
+                        ctx.display(param_range.0),
+                        ctx.display(param_range.1)
+                    ));
+                    labels.push(param);
                 }
 
                 Diagnostic::error()

--- a/fil-ir/src/printer/display_ctx.rs
+++ b/fil-ir/src/printer/display_ctx.rs
@@ -156,11 +156,7 @@ impl<'a> DisplayCtx<&'a ir::Liveness> for ir::Component {
         write!(
             f,
             "for<{}: {}> {}",
-            if let Some(idx) = idx {
-                self.display(*idx)
-            } else {
-                "_".to_string()
-            },
+            self.display(*idx),
             self.display(*len),
             self.display(range)
         )

--- a/fil-ir/src/structure.rs
+++ b/fil-ir/src/structure.rs
@@ -128,7 +128,7 @@ impl fmt::Display for Direction {
 /// p[N]: for<i> @['G, 'G+i+10]
 /// ```
 pub struct Liveness {
-    pub idx: Option<ParamIdx>,
+    pub idx: ParamIdx,
     pub len: ExprIdx,
     pub range: Range,
 }
@@ -251,23 +251,19 @@ impl Access {
     /// Return the bundle type associated with this access
     pub fn bundle_typ(&self, ctx: &mut Component) -> Liveness {
         let live = ctx.get(self.port).live.clone();
-        let Some(idx) = live.idx else {
-            // If there is no bound parameter, then all accesses have the same type
-            return live;
-        };
         let binding = if self.is_port(ctx) {
-            // If this access produces exactly one port, then remap `idx` to `start`.
-            [(idx, self.start)]
+            // If this access produces exactly one port, then remap `#idx` to `start`.
+            [(live.idx, self.start)]
         } else {
             // Remap `#idx` to `#idx+start
-            [(idx, idx.expr(ctx).add(self.start, ctx))]
+            [(live.idx, live.idx.expr(ctx).add(self.start, ctx))]
         };
 
         let range = Subst::new(live.range, &Bind::new(binding)).apply(ctx);
         // Shrink the bundle type based on the access
         let len = self.end.sub(self.start, ctx);
         Liveness {
-            idx: Some(idx),
+            idx: live.idx,
             len,
             range,
         }

--- a/fil-ir/src/validate.rs
+++ b/fil-ir/src/validate.rs
@@ -63,11 +63,8 @@ impl<'a> Validate<'a> {
     fn port(&self, pidx: ir::PortIdx) {
         let ir::Port { owner, live, .. } = self.comp.get(pidx);
         // check (1)
-        if let ir::Liveness {
-            idx: Some(par_idx), ..
-        } = live
-        {
-            match self.comp.get(*par_idx).owner {
+        let ir::Liveness { idx: par_idx, .. } = live;
+        match self.comp.get(*par_idx).owner {
             ir::ParamOwner::Sig => self.comp.internal_error(format!(
                 "{} should be owned by a bundle but is owned by a sig",
                 self.comp.display(*par_idx)
@@ -91,7 +88,6 @@ impl<'a> Validate<'a> {
                         format!("{par_idx} should be owned by {pidx} but is owned by {port_idx}"))
                 }
             }
-        }
         }
 
         // check (2)

--- a/src/ir_passes/mono/monosig.rs
+++ b/src/ir_passes/mono/monosig.rs
@@ -712,10 +712,9 @@ impl MonoSig {
 
         let ir::Liveness { idx, len, range } = live;
 
-        let mono_liveness_idx = idx.map(|idx| {
-            self.bundle_param(underlying, pass, idx.ul(), new_port)
-                .get()
-        });
+        let mono_liveness_idx = self
+            .bundle_param(underlying, pass, idx.ul(), new_port)
+            .get();
 
         let mut mono_liveness = ir::Liveness {
             idx: mono_liveness_idx,
@@ -857,19 +856,16 @@ impl MonoSig {
 
         let ir::Liveness { idx, len, range } = live;
 
-        let mono_liveness_idx = idx
-            .map(|idx| self.bundle_param(underlying, pass, idx.ul(), new_port));
+        let mono_liveness_idx =
+            self.bundle_param(underlying, pass, idx.ul(), new_port);
 
         let mut mono_liveness = ir::Liveness {
-            idx: mono_liveness_idx.map(|idx| idx.get()),
+            idx: mono_liveness_idx.get(),
             len: *len,            // placeholder
             range: range.clone(), // placeholder
         };
 
-        if let Some(m_idx) = mono_liveness_idx {
-            self.bundle_param_map.insert(new_port, m_idx);
-        }
-
+        self.bundle_param_map.insert(new_port, mono_liveness_idx);
         let mono_width = self.expr(underlying, width.ul());
         mono_liveness.len = self.expr(underlying, mono_liveness.len.ul()).get();
         mono_liveness.len = self


### PR DESCRIPTION
Turns out even bundles with liveness that doesn't use the index parameter in the type needs the parameter to encode the length constraints so functionally, this is not useful to do.