### PR TITLE
Remove implications being generated with `false` left hand sides.

### DIFF
--- a/tests/check/false-implication.fil
+++ b/tests/check/false-implication.fil
@@ -3,7 +3,9 @@ comp main<'G: 1>() -> () {
   let T = 1;
   if T == 0 {
     assert T == 0;
+    assume T == 0;
   } else {
     assert T == 1;
+    assume T == 1;
   }
 }

--- a/tests/check/false-implication.fil
+++ b/tests/check/false-implication.fil
@@ -1,0 +1,9 @@
+/// Checks that no false implication is generated when local parameters are elided.
+comp main<'G: 1>() -> () {
+  let T = 1;
+  if T == 0 {
+    assert T == 0;
+  } else {
+    assert T == 1;
+  }
+}

--- a/tests/errors/well-formed/false-implication.expect
+++ b/tests/errors/well-formed/false-implication.expect
@@ -1,0 +1,5 @@
+---CODE---
+101
+---STDERR---
+thread 'main' panicked at 'Attempted to assume false', fil-ir/src/comp.rs:119:13
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/errors/well-formed/false-implication.fil
+++ b/tests/errors/well-formed/false-implication.fil
@@ -1,0 +1,11 @@
+/// Checks that no false implication is generated when local parameters are elided.
+comp main<'G: 1>() -> () {
+  let T = 1;
+  if T == 0 {
+    assert T == 1;
+    assume T == 1;
+  } else {
+    assert T == 0;
+    assume T == 0;
+  }
+}


### PR DESCRIPTION
The issue is caused by let-bound parameters eliding away into expressions like `0 == 1` in if statements, which results in assumptions/assertions generated inside to become `False => ??`.

The solution is to eliminate false branches and not convert them at all.