### PR TITLE
Bump Calyx docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cucapra/calyx:0.4.0
+FROM ghcr.io/cucapra/calyx:latest
 
 LABEL org.opencontainers.image.source https://github.com/cucapra/filament
 


### PR DESCRIPTION
Filament wasn't building before because we needed to update the Rust version. I just changed the Dockerfile to use a newer version of the Calyx Dockerfile