### PR TITLE
Instance borrow ranges can reference instance

### DIFF
--- a/fil-ir/src/from_ast/astconv.rs
+++ b/fil-ir/src/from_ast/astconv.rs
@@ -46,14 +46,18 @@ impl<'prog> BuildCtx<'prog> {
             self.diag(),
         )?;
         let mut live_locs = Vec::with_capacity(lives.len());
-        let lives = lives
-            .iter()
-            .map(|l| {
-                let (l, pos) = l.clone().split();
-                live_locs.push(pos);
-                self.range(l)
-            })
-            .collect::<BuildRes<Vec<_>>>()?;
+        lives.iter().for_each(|l| {
+            let (_, pos) = l.clone().split();
+            live_locs.push(pos);
+        });
+        // let lives = lives
+        //     .iter()
+        //     .map(|l| {
+        //         let (l, pos) = l.clone().split();
+        //         live_locs.push(pos);
+        //         self.range(l)
+        //     })
+        // .collect::<BuildRes<Vec<_>>>()?;
         let inst = ir::Instance {
             comp: comp.idx,
             args: binding
@@ -68,7 +72,7 @@ impl<'prog> BuildCtx<'prog> {
                 name.pos(),
                 live_locs,
             )),
-            lives,
+            lives: Vec::default(), // fill this in later so we can reference the instance
         };
 
         let idx = self.comp().add(inst);
@@ -114,6 +118,16 @@ impl<'prog> BuildCtx<'prog> {
 
         self.add_inst(name.copy(), idx);
         // Track the component binding for this instance
+
+        // fill in lives here after we've added the instance name
+        let lives = lives.iter().map(|l| {
+            let (l, _) = l.clone().split();
+            self.range(l)
+        }).collect::<BuildRes<Vec<_>>>()?;
+
+        let inst = self.comp().get_mut(idx);
+        inst.lives.extend(lives);
+
         self.inst_to_sig
             .push(idx, (Rc::new(binding), component.clone()));
         Ok(())

--- a/fil-ir/src/from_ast/astconv.rs
+++ b/fil-ir/src/from_ast/astconv.rs
@@ -50,14 +50,6 @@ impl<'prog> BuildCtx<'prog> {
             let (_, pos) = l.clone().split();
             live_locs.push(pos);
         });
-        // let lives = lives
-        //     .iter()
-        //     .map(|l| {
-        //         let (l, pos) = l.clone().split();
-        //         live_locs.push(pos);
-        //         self.range(l)
-        //     })
-        // .collect::<BuildRes<Vec<_>>>()?;
         let inst = ir::Instance {
             comp: comp.idx,
             args: binding
@@ -120,10 +112,13 @@ impl<'prog> BuildCtx<'prog> {
         // Track the component binding for this instance
 
         // fill in lives here after we've added the instance name
-        let lives = lives.iter().map(|l| {
-            let (l, _) = l.clone().split();
-            self.range(l)
-        }).collect::<BuildRes<Vec<_>>>()?;
+        let lives = lives
+            .iter()
+            .map(|l| {
+                let (l, _) = l.clone().split();
+                self.range(l)
+            })
+            .collect::<BuildRes<Vec<_>>>()?;
 
         let inst = self.comp().get_mut(idx);
         inst.lives.extend(lives);

--- a/tests/check/borrow.fil
+++ b/tests/check/borrow.fil
@@ -1,0 +1,9 @@
+comp Foo<'G:1>() -> () with {
+  some A where A <= 10;
+} {
+  A := 2;
+}
+
+comp main<'G:10>() -> () {
+  F := new Foo in ['G, 'G + F::A];
+}

--- a/tests/errors/typecheck/borrow.expect
+++ b/tests/errors/typecheck/borrow.expect
@@ -1,0 +1,13 @@
+---CODE---
+1
+---STDERR---
+error: event's delay must be greater than the instance's borrow length
+  ┌─ tests/errors/typecheck/borrow.fil:8:19
+  │
+7 │ comp main<'G:10>() -> () {
+  │              -- event's delay is 10 cycles
+8 │   F := new Foo in ['G, 'G + F::A];
+  │                   ^^^^^^^^^^^^^^^ instance borrowed for F::A cycles
+
+Compilation failed with 1 errors.
+Run with --show-models to generate assignments for failing constraints.

--- a/tests/errors/typecheck/borrow.fil
+++ b/tests/errors/typecheck/borrow.fil
@@ -1,0 +1,9 @@
+comp Foo<'G:1>() -> () with {
+  some A;
+} {
+  A := 2;
+}
+
+comp main<'G:10>() -> () {
+  F := new Foo in ['G, 'G + F::A];
+}


### PR DESCRIPTION
Closes #419 
Ended up being a little tweak in `astconv`. When we initially construct the `ir::Instance`, I had it use an empty `Vec` for the `lives` field, and then fill it in after we've already made the source-level name to idx binding in the ctx. This will let us use an instance's existential parameters in its borrow range.

Also adds two small tests, one where it typechecks and one where it doesn't because there aren't any constraints on the existential parameter.