### PR TITLE
Fix shift reg indices

### DIFF
--- a/primitives/state.fil
+++ b/primitives/state.fil
@@ -73,6 +73,6 @@ comp Shift[W, D, ?N=1]<'G: 1>(
       f{i+1} = d.out;
    }
    out_split := new SplitWire[W, N]<'G+D>(f{D});
-   out = out_split.out;
+   out{0..N} = out_split.out{0..N};
 }
 /* ANCHOR_END: shift */


### PR DESCRIPTION
Made a silly mistake that I didn't catch in the other PR, didn't realize you need to do `a{0..N} = b{0..N}` instead of just `a = b` when doing bundle assignments. 