### PR TITLE
Bump to latest Calyx version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ fil-ir = { version = "0.1.0", path = "fil-ir" }
 fil-derive = { version = "0.1.0", path = "fil-derive" }
 fil-gen = { version = "0.1.0", path = "fil-gen" }
 
-calyx-ir = { version = "0.6.0" }
-calyx-frontend = { version = "0.6.0" }
-calyx-utils = { version = "0.6.0" }
-calyx-opt = { version = "0.6.0" }
-calyx-backend = { version = "0.6.0" }
+calyx-ir = { version = "0.7.1" }
+calyx-frontend = { version = "0.7.1" }
+calyx-utils = { version = "0.7.1" }
+calyx-opt = { version = "0.7.1" }
+calyx-backend = { version = "0.7.1" }
 
 [workspace.dependencies.env_logger]
 version = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,7 @@ fn gen_verilog(mut ctx: calyx_ir::Context) -> Result<(), calyx_utils::Error> {
         synthesis_mode: false,
         enable_verification: false,
         flat_assign: true,
+        emit_primitive_extmodules: false,
     };
     ctx.bc = backend_conf;
     pm.execute_plan(


### PR DESCRIPTION
We should start generate `static` components with the Calyx backend so that Calyx components can start interfacing and consuming Filament-generated code