### PR TITLE
Add simple if-exprs

### DIFF
--- a/crates/ast/src/constraint.rs
+++ b/crates/ast/src/constraint.rs
@@ -1,7 +1,7 @@
 use super::{Binding, Expr, Time, TimeSub};
 
 /// Ordering operator for constraints
-#[derive(Hash, Eq, PartialEq, Clone)]
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub enum OrderOp {
     Gt,
     Gte,
@@ -19,7 +19,7 @@ impl std::fmt::Display for OrderOp {
 }
 
 // An ordering constraint
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct OrderConstraint<T> {
     pub left: T,
     pub right: T,
@@ -93,6 +93,26 @@ impl OrderConstraint<Expr> {
     }
 }
 
+impl OrderConstraint<Box<Expr>> {
+    pub fn resolve_expr(self, binding: &Binding<Expr>) -> Self {
+        OrderConstraint {
+            left: Box::new(self.left.resolve(binding)),
+            right: Box::new(self.right.resolve(binding)),
+            ..self
+        }
+    }
+
+    pub fn exprs(&self) -> Vec<&Expr> {
+        vec![&self.left, &self.right]
+    }
+}
+
+// impl std::fmt::Debug for OrderConstraint<Box<Expr>> {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         f.debug_struct("OrderConstraint").field("left", &self.left).field("right", &self.right).field("op", &self.op).finish()
+//     }
+// }
+
 impl OrderConstraint<Time> {
     pub fn resolve_event(self, bindings: &Binding<Time>) -> Self {
         OrderConstraint {
@@ -120,7 +140,7 @@ impl OrderConstraint<TimeSub> {
         }
     }
 
-    fn resolve_expr(self, bindings: &Binding<Expr>) -> Self {
+    pub fn resolve_expr(self, bindings: &Binding<Expr>) -> Self {
         OrderConstraint {
             left: self.left.resolve_expr(bindings),
             right: self.right.resolve_expr(bindings),

--- a/crates/ast/src/parser.rs
+++ b/crates/ast/src/parser.rs
@@ -290,10 +290,18 @@ impl FilamentParser {
         Ok(match_nodes!(
             input.into_children();
             [identifier(inst), identifier(param)] => ast::Expr::ParamAccess{ inst, param },
+            [if_expr(e)] => e.into(),
             [param_var(id)] => ast::Expr::abs(id),
             [bitwidth(c)] => c.into(),
             [r#fn(f), expr(exprs)..] => ast::Expr::func(f, exprs.into_iter().map(|e| e.take()).collect()),
             [expr(e)] => e.take(),
+        ))
+    }
+
+    fn if_expr(input: Node) -> ParseResult<ast::Expr> {
+        Ok(match_nodes!(
+            input.clone().into_children();
+            [expr_cmp(cond), expr(then), expr(alt)] => ast::Expr::if_expr(cond, then.take(), alt.take()),
         ))
     }
 

--- a/crates/ast/src/parser.rs
+++ b/crates/ast/src/parser.rs
@@ -290,7 +290,7 @@ impl FilamentParser {
         Ok(match_nodes!(
             input.into_children();
             [identifier(inst), identifier(param)] => ast::Expr::ParamAccess{ inst, param },
-            [if_expr(e)] => e.into(),
+            [if_expr(e)] => e,
             [param_var(id)] => ast::Expr::abs(id),
             [bitwidth(c)] => c.into(),
             [r#fn(f), expr(exprs)..] => ast::Expr::func(f, exprs.into_iter().map(|e| e.take()).collect()),

--- a/crates/ast/src/syntax.pest
+++ b/crates/ast/src/syntax.pest
@@ -91,6 +91,10 @@ op_add = { "+" }
 op_sub = { "-" }
 operator = _{ op_mul | op_div | op_add | op_sub | op_mod }
 
+if_expr = {
+  "if" ~ expr_cmp ~ "{" ~ expr ~ "}" ~ "else" ~ "{" ~ expr ~ "}"
+}
+
 builtin_fn = {
   | "pow2"
   | "log2"
@@ -102,6 +106,7 @@ unknown_fn = { identifier }
 fn = {builtin_fn | unknown_fn}
 
 expr_base = {
+  | if_expr
   | fn ~ "(" ~ expr ~ ("," ~ expr)* ~ ")"
   | "(" ~ expr ~ ")"
   | bitwidth

--- a/crates/filament/src/ir_passes/discharge.rs
+++ b/crates/filament/src/ir_passes/discharge.rs
@@ -666,15 +666,11 @@ impl Visitor for Discharge {
         for (idx, prop) in data.comp.props().iter() {
             // Define assertion equating the proposition to its assignment
             let assign = self.prop_to_sexp(prop);
-            let sexp_res =
-                self.sol.define_const(Discharge::fmt_prop(idx), bs, assign);
-            match sexp_res {
-                Ok(_) => {
-                    self.prop_map
-                        .insert(idx, SExprWrapper::SExpr(sexp_res.unwrap()));
-                }
-                Err(_) => (),
-            };
+            if let Ok(sexp) =
+                self.sol.define_const(Discharge::fmt_prop(idx), bs, assign)
+            {
+                self.prop_map.insert(idx, SExprWrapper::SExpr(sexp));
+            }
         }
         // Pass does not need to traverse the control program.
         Action::Continue

--- a/crates/filament/src/ir_passes/discharge.rs
+++ b/crates/filament/src/ir_passes/discharge.rs
@@ -26,12 +26,6 @@ impl Default for SExprWrapper {
     }
 }
 
-impl From<easy_smt::SExpr> for SExprWrapper {
-    fn from(value: easy_smt::SExpr) -> Self {
-        Self::SExpr(value)
-    }
-}
-
 impl SExprWrapper {
     fn get(&self) -> easy_smt::SExpr {
         match self {

--- a/crates/filament/src/ir_passes/discharge.rs
+++ b/crates/filament/src/ir_passes/discharge.rs
@@ -481,6 +481,12 @@ impl Discharge {
                     iter::once(self.func_map[op]).chain(args).collect_vec(),
                 )
             }
+            ir::Expr::If { cond, then, alt } => {
+                let then = self.expr_map[*then];
+                let alt = self.expr_map[*alt];
+                let cond = self.prop_map[*cond];
+                self.sol.list(vec![then, alt, cond])
+            }
         }
     }
 

--- a/crates/filament/src/ir_passes/lower/utils.rs
+++ b/crates/filament/src/ir_passes/lower/utils.rs
@@ -61,7 +61,9 @@ impl NameGenerator {
                 value: self.param_name(*p, comp).into(),
             },
             ir::Expr::Concrete(val) => calyx::Width::Const { value: *val },
-            ir::Expr::Bin { .. } | ir::Expr::Fn { .. } => comp
+            ir::Expr::Bin { .. }
+            | ir::Expr::Fn { .. }
+            | ir::Expr::If { .. } => comp
                 .internal_error("Port width must be a parameter or constant."),
         }
     }

--- a/crates/ir/src/control.rs
+++ b/crates/ir/src/control.rs
@@ -1,4 +1,4 @@
-use crate::{Expr, Time};
+use crate::{Expr, Prop, Time};
 
 use super::{
     Access, CompIdx, Component, Ctx, Event, ExprIdx, Fact, Foreign, InfoIdx,
@@ -108,7 +108,7 @@ impl InstIdx {
 
     pub fn relevant_vars(
         self,
-        ctx: &(impl Ctx<Instance> + Ctx<Expr> + Ctx<Time>),
+        ctx: &(impl Ctx<Instance> + Ctx<Expr> + Ctx<Time> + Ctx<Prop>),
     ) -> Vec<ParamIdx> {
         let Instance { args, lives, .. } = ctx.get(self);
         args.iter()

--- a/crates/ir/src/expr.rs
+++ b/crates/ir/src/expr.rs
@@ -112,6 +112,30 @@ impl ExprIdx {
 
 /// Queries over [ExprIdx]
 impl ExprIdx {
+    pub fn relevant_props(
+        &self,
+        ctx: &(impl Ctx<Expr> + Ctx<Prop>),
+    ) -> Vec<PropIdx> {
+        let mut props = Vec::new();
+        self.relevant_props_acc(ctx, &mut props);
+        props
+    }
+
+    pub fn relevant_props_acc(
+        &self,
+        ctx: &(impl Ctx<Expr> + Ctx<Prop>),
+        props: &mut Vec<PropIdx>,
+    ) {
+        match ctx.get(*self) {
+            Expr::If { cond, .. } => {
+                props.push(*cond);
+                let inner_props = cond.relevant_props(ctx);
+                props.extend(inner_props);
+            }
+            _ => (),
+        }
+    }
+
     pub fn relevant_vars(
         &self,
         ctx: &(impl Ctx<Expr> + Ctx<Prop>),

--- a/crates/ir/src/expr.rs
+++ b/crates/ir/src/expr.rs
@@ -1,5 +1,5 @@
 use super::{AddCtx, Component, Ctx, ExprIdx, ParamIdx};
-use crate::construct_binop;
+use crate::{construct_binop, Prop, PropIdx};
 use fil_ast as ast;
 use std::fmt::Display;
 
@@ -16,6 +16,11 @@ pub enum Expr {
         op: ast::Fn,
         args: Vec<ExprIdx>,
     },
+    If {
+        cond: PropIdx,
+        then: ExprIdx,
+        alt: ExprIdx,
+    },
 }
 
 impl Display for Expr {
@@ -31,6 +36,9 @@ impl Display for Expr {
                     .collect::<Vec<_>>()
                     .join(", ");
                 write!(f, "{}({})", op, args)
+            }
+            Expr::If { cond, then, alt } => {
+                write!(f, "if {} then {} else {}", cond, then, alt)
             }
         }
     }
@@ -104,7 +112,10 @@ impl ExprIdx {
 
 /// Queries over [ExprIdx]
 impl ExprIdx {
-    pub fn relevant_vars(&self, ctx: &impl Ctx<Expr>) -> Vec<ParamIdx> {
+    pub fn relevant_vars(
+        &self,
+        ctx: &(impl Ctx<Expr> + Ctx<Prop>),
+    ) -> Vec<ParamIdx> {
         let mut params = Vec::new();
         self.relevant_vars_acc(ctx, &mut params);
         params
@@ -112,7 +123,7 @@ impl ExprIdx {
 
     pub fn relevant_vars_acc(
         &self,
-        ctx: &impl Ctx<Expr>,
+        ctx: &(impl Ctx<Expr> + Ctx<Prop>),
         params: &mut Vec<ParamIdx>,
     ) {
         match ctx.get(*self) {
@@ -128,6 +139,11 @@ impl ExprIdx {
                 for e in args {
                     e.relevant_vars_acc(ctx, params);
                 }
+            }
+            Expr::If { cond, then, alt } => {
+                cond.relevant_vars_if_acc(ctx, params);
+                then.relevant_vars_acc(ctx, params);
+                alt.relevant_vars_acc(ctx, params);
             }
         }
     }

--- a/crates/ir/src/expr.rs
+++ b/crates/ir/src/expr.rs
@@ -126,13 +126,10 @@ impl ExprIdx {
         ctx: &(impl Ctx<Expr> + Ctx<Prop>),
         props: &mut Vec<PropIdx>,
     ) {
-        match ctx.get(*self) {
-            Expr::If { cond, .. } => {
-                props.push(*cond);
-                let inner_props = cond.relevant_props(ctx);
-                props.extend(inner_props);
-            }
-            _ => (),
+        if let Expr::If { cond, .. } = ctx.get(*self) {
+            props.push(*cond);
+            let inner_props = cond.relevant_props(ctx);
+            props.extend(inner_props);
         }
     }
 

--- a/crates/ir/src/fact.rs
+++ b/crates/ir/src/fact.rs
@@ -232,6 +232,29 @@ impl PropIdx {
         }
     }
 
+    // relevant vars of an if guard -- can't include times
+    pub fn relevant_vars_if_acc(
+        &self,
+        ctx: &(impl Ctx<Prop> + Ctx<Expr>),
+        param_acc: &mut Vec<ParamIdx>,
+    ) {
+        match ctx.get(*self) {
+            Prop::True | Prop::False => (),
+            Prop::Cmp(CmpOp { lhs, rhs, .. }) => {
+                lhs.relevant_vars_acc(ctx, param_acc);
+                rhs.relevant_vars_acc(ctx, param_acc);
+            }
+            Prop::TimeCmp(_) | Prop::TimeSubCmp(_) => {
+                panic!("if-expr guards cannot contain times");
+            }
+            Prop::Not(p) => p.relevant_vars_if_acc(ctx, param_acc),
+            Prop::And(l, r) | Prop::Or(l, r) | Prop::Implies(l, r) => {
+                l.relevant_vars_if_acc(ctx, param_acc);
+                r.relevant_vars_if_acc(ctx, param_acc)
+            }
+        }
+    }
+
     /// Accumulate all the parameters and events that appear in this proposition.
     pub fn relevant_vars_acc(
         &self,
@@ -287,6 +310,15 @@ impl PropIdx {
         let mut events = Vec::new();
         self.relevant_vars_acc(ctx, &mut params, &mut events);
         (params, events)
+    }
+
+    pub fn relevant_vars_if(
+        &self,
+        ctx: &(impl Ctx<Prop> + Ctx<Expr>),
+    ) -> Vec<ParamIdx> {
+        let mut params = Vec::new();
+        self.relevant_vars_if_acc(ctx, &mut params);
+        params
     }
 }
 

--- a/crates/ir/src/fact.rs
+++ b/crates/ir/src/fact.rs
@@ -320,6 +320,43 @@ impl PropIdx {
         self.relevant_vars_if_acc(ctx, &mut params);
         params
     }
+
+    pub fn relevant_props(
+        &self,
+        ctx: &(impl Ctx<Prop> + Ctx<Expr>),
+    ) -> Vec<PropIdx> {
+        let mut props = Vec::new();
+        self.relevant_props_acc(ctx, &mut props);
+        props
+    }
+
+    pub fn relevant_props_acc(
+        &self,
+        ctx: &(impl Ctx<Prop> + Ctx<Expr>),
+        props: &mut Vec<PropIdx>,
+    ) {
+        match ctx.get(*self) {
+            Prop::True | Prop::False => (),
+            Prop::Cmp(CmpOp { lhs, rhs, .. }) => {
+                let lhs_props = lhs.relevant_props(ctx);
+                let rhs_props = rhs.relevant_props(ctx);
+                props.extend(lhs_props);
+                props.extend(rhs_props);
+            }
+            Prop::TimeCmp(_) => todo!(),
+            Prop::TimeSubCmp(_) => todo!(),
+            Prop::Not(p) => {
+                let inner_props = p.relevant_props(ctx);
+                props.extend(inner_props);
+            }
+            Prop::And(l, r) | Prop::Or(l, r) | Prop::Implies(l, r) => {
+                let l_props = l.relevant_props(ctx);
+                let r_props = r.relevant_props(ctx);
+                props.extend(l_props);
+                props.extend(r_props);
+            }
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/crates/ir/src/from_ast/astconv.rs
+++ b/crates/ir/src/from_ast/astconv.rs
@@ -274,6 +274,17 @@ impl<'prog> BuildCtx<'prog> {
                 // The .add call simplifies the expression if possible
                 self.comp().add(ir::Expr::Fn { op: func, args })
             }
+            ast::Expr::If { cond, then, alt } => {
+                let ast::OrderConstraint { left, right, op } = cond;
+                let cond = self.expr_cons(ast::OrderConstraint {
+                    left: *left,
+                    right: *right,
+                    op,
+                })?;
+                let then = self.expr(*then)?;
+                let alt = self.expr(*alt)?;
+                self.comp().add(ir::Expr::If { cond, then, alt })
+            }
         };
         Ok(expr)
     }

--- a/crates/ir/src/printer/prop.rs
+++ b/crates/ir/src/printer/prop.rs
@@ -1,9 +1,10 @@
 use super::{DisplayCtx, IOResult};
 use crate::{self as ir, Ctx};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 /// Context to track proposition bindings
 pub enum PCtx {
+    #[default]
     Not,
     Cmp,
     And,
@@ -62,7 +63,7 @@ where
     }
 }
 
-fn display_prop_helper(
+pub fn display_prop_helper(
     prop: ir::PropIdx,
     ctx: PCtx,
     comp: &ir::Component,

--- a/crates/ir/src/time.rs
+++ b/crates/ir/src/time.rs
@@ -1,4 +1,4 @@
-use crate::DisplayCtx;
+use crate::{DisplayCtx, Prop};
 
 use super::{
     AddCtx, Component, Ctx, EventIdx, Expr, ExprIdx, Foldable, ParamIdx,
@@ -56,7 +56,7 @@ impl TimeIdx {
 
     pub fn relevant_vars(
         self,
-        ctx: &(impl Ctx<Time> + Ctx<Expr>),
+        ctx: &(impl Ctx<Time> + Ctx<Expr> + Ctx<Prop>),
     ) -> Vec<ParamIdx> {
         let time = ctx.get(self);
         time.offset.relevant_vars(ctx)

--- a/crates/ir/src/utils/subst.rs
+++ b/crates/ir/src/utils/subst.rs
@@ -185,6 +185,12 @@ impl Foldable<ParamIdx, ExprIdx> for ExprIdx {
                     .collect();
                 ctx.add(Expr::Fn { op, args })
             }
+            Expr::If { cond, then, alt } => {
+                let cond = cond.fold_with(ctx, subst_fn);
+                let then = then.fold_with(ctx, subst_fn);
+                let alt = alt.fold_with(ctx, subst_fn);
+                ctx.add(Expr::If { cond, then, alt })
+            }
         }
     }
 }

--- a/tests/check/if-expr.fil
+++ b/tests/check/if-expr.fil
@@ -1,0 +1,12 @@
+import "primitives/core.fil";
+
+comp main<'G:1>() -> (out: ['G, 'G+1] 32) {
+    f := new Foo[1]<'G>();
+    out = f.out;
+}
+
+comp Foo[M]<'G:1>() -> (out: ['G, 'G+1] 32) {
+    let i = if M == 1 {1} else {2};
+    c := new Const[32, i]<'G>();
+    out = c.out;
+}


### PR DESCRIPTION
Adds if-expressions, closes #436. Each arm of the if currently must be a simple expression; could be extended in a future PR to support blocks of commands that return an expression, if necessary. 

Represented in the IR as another member of `ir::Expr` that takes a condition (`ir::Prop`) and two expressions. This worked pretty okay, just had to do some reshuffling of code in the monomorphize pass to be able to handle `Prop`s at the same time we handle `Expr`s. 

One sort of weird thing happens in `Discharge`, where we need to convert the if's condition (a `Prop`) to an `SExp` as we are converting all of a component's `Expr`s, which happens before we do the rest of the component's `Prop`s. This means that we need to push things to `Discharge::prop_map` out of order, which means that `SExpr` needs to implement `Default`. We can't implement `Default` for `SExpr`, so I made a wrapper `SExprWrapper` that is either an `SExpr` or`SExprEmpty`, which lets us implement `Default`. This is a little wonky, but I couldn't really come up with a way around this.