### PR TITLE
Use full path for filament target in fud configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,4 +94,4 @@ RUN cargo build --all
 RUN python3 -m pip install cocotb find_libpython pytest && \
   fud register -p fud/filament.py filament && \
   fud config stages.filament.exec /home/filament/target/debug/filament && \
-  fud config stages.filament.library .
+  fud config stages.filament.library /home/filament

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,5 +93,5 @@ RUN cargo build --all
 # Set up fud
 RUN python3 -m pip install cocotb find_libpython pytest && \
   fud register -p fud/filament.py filament && \
-  fud config stages.filament.exec target/debug/filament && \
+  fud config stages.filament.exec /home/filament/target/debug/filament && \
   fud config stages.filament.library .


### PR DESCRIPTION
Current setup means fud will only run in the filament home directory.