### PR TITLE
Set languages of doc comments to filament

### DIFF
--- a/crates/ast/src/control.rs
+++ b/crates/ast/src/control.rs
@@ -244,7 +244,7 @@ impl Connect {
 
 #[derive(Clone)]
 /// A generative loop:
-/// ```
+/// ```fil
 /// for i in 0..W { ... }
 /// ```
 pub struct ForLoop {
@@ -296,7 +296,7 @@ impl If {
 
 #[derive(Clone)]
 /// The type of the bundle:
-/// ```
+/// ```fil
 /// for<i> ['G+i, 'G+i+1] W
 /// ```
 pub struct BundleType {
@@ -357,7 +357,7 @@ impl BundleType {
 
 #[derive(Clone)]
 /// Represents a bundle of wires with timing guarantees
-/// ```
+/// ```fil
 /// bundle f[10]: for<i> ['G+i, 'G+i+1] W;
 /// ```
 pub struct Bundle {


### PR DESCRIPTION
Unannotated code blocks are assumed to be Rust code, which rust will [automatically test for compilation](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html). Set these blocks to filament to fix #447 