### PR TITLE
Set up .gitattributes to change line endings to `LF`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
Because `runt` uses `LF` instead of `CRLF` line endings, certain tests that for some reason have `CRLF` endings are failing. this should fix the issue.