### PR TITLE
add `let = ?` binding for temporary Filament automation frontend

### DIFF
--- a/crates/ast/src/control.rs
+++ b/crates/ast/src/control.rs
@@ -386,7 +386,7 @@ impl Bundle {
 pub struct ParamLet {
     pub name: Loc<Id>,
     /// The expression for the parameter binding
-    pub expr: Expr,
+    pub expr: Option<Expr>,
 }
 
 #[derive(Clone)]

--- a/crates/ast/src/parser.rs
+++ b/crates/ast/src/parser.rs
@@ -792,7 +792,8 @@ impl FilamentParser {
     fn param_let(input: Node) -> ParseResult<ast::ParamLet> {
         Ok(match_nodes!(
             input.into_children();
-            [param_var(name), expr(expr)] => ast::ParamLet { name, expr: expr.take() }
+            [param_var(name), expr(expr)] => ast::ParamLet { name, expr: Some(expr.take()) },
+            [param_var(name)] => ast::ParamLet { name, expr: None }
         ))
     }
 

--- a/crates/ast/src/syntax.pest
+++ b/crates/ast/src/syntax.pest
@@ -257,6 +257,7 @@ if_stmt = {
 // ===== let-bound parameters ========
 param_let = {
   "let" ~ param_var ~ "=" ~ expr ~ ";"
+  | "let" ~ param_var ~ "=" ~ "?" ~ ";"
 }
 
 // ====== Loops ==========

--- a/crates/filament/src/ir_passes/build_domination.rs
+++ b/crates/filament/src/ir_passes/build_domination.rs
@@ -73,15 +73,17 @@ impl BuildDomination {
         for (id, cmd) in cmds.iter().enumerate() {
             match cmd {
                 ir::Command::Let(ir::Let { expr, param }) => {
-                    for idx in expr.relevant_vars(comp) {
-                        log::trace!(
-                            "param {} is used by {}",
-                            comp.display(idx),
-                            comp.display(*param)
-                        );
-                        if let Some(pid) = param_map.get(&idx) {
-                            // Add a dependency from the let to the parameter owner, if it is defined in this scope
-                            topo.add_dependency(*pid, id);
+                    if let Some(expr) = expr {
+                        for idx in expr.relevant_vars(comp) {
+                            log::trace!(
+                                "param {} is used by {}",
+                                comp.display(idx),
+                                comp.display(*param)
+                            );
+                            if let Some(pid) = param_map.get(&idx) {
+                                // Add a dependency from the let to the parameter owner, if it is defined in this scope
+                                topo.add_dependency(*pid, id);
+                            }
                         }
                     }
                 }

--- a/crates/filament/src/ir_passes/discharge.rs
+++ b/crates/filament/src/ir_passes/discharge.rs
@@ -636,7 +636,7 @@ impl Visitor for Discharge {
 
         // Assert bindings for all let-bound parameters
         for (idx, p) in data.comp.params().iter() {
-            let ir::ParamOwner::Let { bind } = &p.owner else {
+            let ir::ParamOwner::Let { bind: Some(bind) } = &p.owner else {
                 continue;
             };
             let param_s = self.param_map[idx];

--- a/crates/filament/src/ir_passes/mono/monodeferred.rs
+++ b/crates/filament/src/ir_passes/mono/monodeferred.rs
@@ -342,7 +342,14 @@ impl MonoDeferred<'_, '_> {
                 let p = param.ul();
                 let e = self
                     .monosig
-                    .expr(&self.underlying, expr.ul(), self.pass)
+                    .expr(
+                        &self.underlying,
+                        expr.unwrap_or_else(|| {
+                            unreachable!("Let binding was bound to `?`")
+                        })
+                        .ul(),
+                        self.pass,
+                    )
                     .get();
                 let Some(v) = e.as_concrete(self.monosig.base.comp()) else {
                     unreachable!(

--- a/crates/ir/src/control.rs
+++ b/crates/ir/src/control.rs
@@ -234,5 +234,5 @@ pub struct Let {
     /// The parameter
     pub param: ParamIdx,
     /// The binding for the parameter
-    pub expr: ExprIdx,
+    pub expr: Option<ExprIdx>,
 }

--- a/crates/ir/src/from_ast/astconv.rs
+++ b/crates/ir/src/from_ast/astconv.rs
@@ -213,8 +213,12 @@ impl<'prog> BuildCtx<'prog> {
             ast::Command::ParamLet(ast::ParamLet { name, expr }) => {
                 // Declare the parameter since it may be used in instance or
                 // invocation definitions.
-                let bind = self.expr(expr.clone())?;
-                let owner = ir::ParamOwner::Let { bind };
+                let owner = ir::ParamOwner::Let {
+                    bind: match expr {
+                        Some(expr) => Some(self.expr(expr.clone())?),
+                        None => None,
+                    },
+                };
                 self.param(name.clone(), owner);
                 Ok(())
             }
@@ -979,7 +983,10 @@ impl<'prog> BuildCtx<'prog> {
                         "let-bound parameter was rewritten to expression"
                     )
                 };
-                let expr = self.expr(expr)?;
+                let expr = match expr {
+                    Some(e) => Some(self.expr(e)?),
+                    None => None,
+                };
                 // The declare phase already added the rewrite for this binding
                 vec![ir::Let { param, expr }.into()]
             }

--- a/crates/ir/src/printer/comp.rs
+++ b/crates/ir/src/printer/comp.rs
@@ -48,7 +48,10 @@ impl<'a, 'b> Printer<'a, 'b> {
                 write!(f, "{:indent$}let ", "")?;
                 self.comp.write(*param, f)?;
                 write!(f, " = ")?;
-                self.comp.write(*expr, f)
+                match expr {
+                    Some(expr) => self.comp.write(*expr, f),
+                    None => write!(f, "?"),
+                }
             }
             ir::Command::ForLoop(ir::Loop {
                 index,

--- a/crates/ir/src/structure.rs
+++ b/crates/ir/src/structure.rs
@@ -299,7 +299,7 @@ pub enum ParamOwner {
     /// A `let`-bound variable
     Let {
         /// The value of the parameter in its corresponding binding
-        bind: ExprIdx,
+        bind: Option<ExprIdx>,
     },
     /// Owned by an `exists` binding
     Exists {

--- a/crates/ir/src/validate.rs
+++ b/crates/ir/src/validate.rs
@@ -226,8 +226,14 @@ impl<'a> Validate<'a> {
             self.comp.internal_error(format!(
                 "let binding for `{}' binds it to {} but the owner defines it to {}",
                 self.comp.display(*param),
-                self.comp.display(*expr),
-                self.comp.display(*bind)
+                match expr {
+                    Some(expr) => self.comp.display(*expr),
+                    None => "?".to_string(),
+                },
+                match bind {
+                    Some(bind) => self.comp.display(*bind),
+                    None => "?".to_string(),
+                }
             ))
         }
     }

--- a/tests/errors/binding/let-unbound.expect
+++ b/tests/errors/binding/let-unbound.expect
@@ -1,0 +1,6 @@
+---CODE---
+101
+---STDERR---
+thread 'main' panicked at crates/filament/src/ir_passes/mono/monodeferred.rs:348:29:
+internal error: entered unreachable code: Let binding was bound to `?`
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/errors/binding/let-unbound.fil
+++ b/tests/errors/binding/let-unbound.fil
@@ -1,0 +1,3 @@
+comp main<'G: 1>() -> () {
+  let value = ?;
+}


### PR DESCRIPTION
Adds syntax to the frontend for `let param = ?;` let bindings. Currently these will error out during monomorphization as there is no binding.