### PR TITLE
Fix entrypoint setting with calyx

### DIFF
--- a/crates/filament/src/ir_passes/lower/compile.rs
+++ b/crates/filament/src/ir_passes/lower/compile.rs
@@ -317,11 +317,11 @@ impl Compile {
                 &name_gen,
             );
             bindings.insert(idx, Rc::clone(&comp.signature));
-            calyx_ctx.components.push(comp);
             if ctx.is_main(idx) {
                 log::debug!("Setting entrypoint to {}", idx);
-                calyx_ctx.entrypoint = comp.name.clone();
+                calyx_ctx.entrypoint = comp.name;
             }
+            calyx_ctx.components.push(comp);
         });
 
         // add the fsm components to the calyx context

--- a/crates/filament/src/ir_passes/lower/compile.rs
+++ b/crates/filament/src/ir_passes/lower/compile.rs
@@ -318,6 +318,10 @@ impl Compile {
             );
             bindings.insert(idx, Rc::clone(&comp.signature));
             calyx_ctx.components.push(comp);
+            if ctx.is_main(idx) {
+                log::debug!("Setting entrypoint to {}", idx);
+                calyx_ctx.entrypoint = comp.name.clone();
+            }
         });
 
         // add the fsm components to the calyx context


### PR DESCRIPTION
Turns out setting the `toplevel` attribute is not enough for calyx, and we need to explicitly set an entrypoint.