### PR TITLE
Use python3 in blas testing instead of python

### DIFF
--- a/apps/blas/.gitignore
+++ b/apps/blas/.gitignore
@@ -1,0 +1,3 @@
+test.expect
+test.fil.data
+test.fil.out

--- a/apps/blas/run.sh
+++ b/apps/blas/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 KERNEL=$1
-python apps/blas/util.py -r -n 5 -w 4 -k $KERNEL
+apps/blas/util.py -r -n 5 -w 4 -k $KERNEL
 
 

--- a/apps/blas/util.py
+++ b/apps/blas/util.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 from functools import reduce
 from itertools import chain
@@ -135,6 +137,23 @@ def process_fud_output(fud_output):
 def run_fud(kernel):
     open(kernel+".out", 'w')
     basename,_ = os.path.splitext(kernel)
+
+    print(" ".join([
+        "fud",
+        "e",
+        "--to",
+        "cocotb-out",
+        kernel,
+        "-s",
+        "cocotb.data",
+       kernel+".data",
+        "-s",
+        "calyx.flags",
+        "' -d canonicalize'",
+        "-s",
+        "filament.flags",
+        f" --bindings {basename}.toml"
+        ]))
     subprocess.run([
         "fud",
         "e",

--- a/apps/blas/util.py
+++ b/apps/blas/util.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 from functools import reduce
 from itertools import chain
@@ -137,23 +135,6 @@ def process_fud_output(fud_output):
 def run_fud(kernel):
     open(kernel+".out", 'w')
     basename,_ = os.path.splitext(kernel)
-
-    print(" ".join([
-        "fud",
-        "e",
-        "--to",
-        "cocotb-out",
-        kernel,
-        "-s",
-        "cocotb.data",
-       kernel+".data",
-        "-s",
-        "calyx.flags",
-        "' -d canonicalize'",
-        "-s",
-        "filament.flags",
-        f" --bindings {basename}.toml"
-        ]))
     subprocess.run([
         "fud",
         "e",

--- a/runt.toml
+++ b/runt.toml
@@ -124,7 +124,7 @@ name = "blas"
 paths = ["apps/blas/*/test.fil"]
 expect_dir = "apps/blas/"
 cmd = """
-python3 apps/blas/util.py -r -n 5 -w 4 -k {} && \
+apps/blas/util.py -r -n 5 -w 4 -k {} && \
 dir=$(dirname {}) && \
 rm $dir/test.expect $dir/test.fil.data $dir/test.fil.out
 """

--- a/runt.toml
+++ b/runt.toml
@@ -124,7 +124,7 @@ name = "blas"
 paths = ["apps/blas/*/test.fil"]
 expect_dir = "apps/blas/"
 cmd = """
-python apps/blas/util.py -r -n 5 -w 4 -k {} && \
+python3 apps/blas/util.py -r -n 5 -w 4 -k {} && \
 dir=$(dirname {}) && \
 rm $dir/test.expect $dir/test.fil.data $dir/test.fil.out
 """


### PR DESCRIPTION
Blas tests in `runt.toml` defaults to python which on some systems uses python2.7.