### PR TITLE
Port attributes

### DIFF
--- a/crates/ast/src/control.rs
+++ b/crates/ast/src/control.rs
@@ -1,6 +1,7 @@
 use super::{
     Binding, Expr, Id, Implication, Loc, OrderConstraint, Range, Time,
 };
+use fil_utils::PortAttrs;
 use struct_variant::struct_variant;
 
 #[derive(Clone)]
@@ -365,11 +366,13 @@ pub struct Bundle {
     pub name: Loc<Id>,
     /// Type of the bundle
     pub typ: BundleType,
+    /// Attributes associated with the bundle
+    pub attrs: PortAttrs,
 }
 
 impl Bundle {
-    pub fn new(name: Loc<Id>, typ: BundleType) -> Self {
-        Self { name, typ }
+    pub fn new(name: Loc<Id>, typ: BundleType, attrs: PortAttrs) -> Self {
+        Self { name, typ, attrs }
     }
 
     /// Resolve expressions in the Bundle

--- a/crates/ast/src/parser.rs
+++ b/crates/ast/src/parser.rs
@@ -719,7 +719,7 @@ impl FilamentParser {
     fn bundle_def(input: Node) -> ParseResult<ast::Bundle> {
         match_nodes!(
             input.clone().into_children();
-            [identifier(name), expr(sizes).., bundle_typ((params, range, width))] => {
+            [attributes(attrs), identifier(name), expr(sizes).., bundle_typ((params, range, width))] => {
                 let sizes = sizes.collect_vec();
                 // If no size is specified, treat this is as one dimensional bundle with size 1.
                 let (sizes, s_len) = if sizes.is_empty() {
@@ -739,7 +739,7 @@ impl FilamentParser {
                     params.push(Loc::unknown(ast::Id::from(format!("_{i}"))));
                 });
 
-                Ok(ast::Bundle::new(name, ast::BundleType::new(params, sizes, range, width)))
+                Ok(ast::Bundle::new(name, ast::BundleType::new(params, sizes, range, width), attrs))
             }
         )
     }

--- a/crates/ast/src/syntax.pest
+++ b/crates/ast/src/syntax.pest
@@ -175,7 +175,7 @@ bundle_typ = {
 
 // Bundle definition
 bundle_def = {
-  identifier ~ ("[" ~ expr ~ "]")* ~ ":" ~ bundle_typ
+  attributes ~ identifier ~ ("[" ~ expr ~ "]")* ~ ":" ~ bundle_typ
 }
 
 // Ports

--- a/crates/filament/src/ir_passes/bundle_elim.rs
+++ b/crates/filament/src/ir_passes/bundle_elim.rs
@@ -69,6 +69,7 @@ impl BundleElim {
             width,
             live,
             info,
+            attrs,
         } = comp.get(pidx).clone();
 
         let Liveness { idxs, lens, range } = live;
@@ -152,6 +153,7 @@ impl BundleElim {
                     owner,
                     info, // duplicate the info
                     width,
+                    attrs: attrs.clone(),
                 });
 
                 // Fill in the live idxs with a new dummy index

--- a/crates/filament/src/ir_passes/bundle_elim.rs
+++ b/crates/filament/src/ir_passes/bundle_elim.rs
@@ -69,8 +69,9 @@ impl BundleElim {
             width,
             live,
             info,
-            attrs,
         } = comp.get(pidx).clone();
+
+        let attrs = comp.port_attrs.get(pidx).clone();
 
         let Liveness { idxs, lens, range } = live;
 
@@ -153,8 +154,10 @@ impl BundleElim {
                     owner,
                     info, // duplicate the info
                     width,
-                    attrs: attrs.clone(),
                 });
+
+                // copy over the attributes
+                comp.port_attrs.push(pidx, attrs.clone());
 
                 // Fill in the live idxs with a new dummy index
                 let port = ir::Param {

--- a/crates/filament/src/ir_passes/mono/monosig.rs
+++ b/crates/filament/src/ir_passes/mono/monosig.rs
@@ -800,6 +800,7 @@ impl MonoSig {
             width,
             live,
             info,
+            attrs,
         } = underlying.get(port);
 
         let inv = match owner {
@@ -820,6 +821,7 @@ impl MonoSig {
             width: *width,      // placeholder
             live: live.clone(), // placeholder
             info: info.get(),
+            attrs: attrs.clone(),
         });
 
         // Overwrite the value in the port map if any. This is okay because this

--- a/crates/filament/src/ir_passes/mono/monosig.rs
+++ b/crates/filament/src/ir_passes/mono/monosig.rs
@@ -800,8 +800,8 @@ impl MonoSig {
             width,
             live,
             info,
-            attrs,
         } = underlying.get(port);
+        let attrs = underlying.port_attrs().get(port.idx());
 
         let inv = match owner {
             ir::PortOwner::Sig { .. } | ir::PortOwner::Local => None,
@@ -821,8 +821,9 @@ impl MonoSig {
             width: *width,      // placeholder
             live: live.clone(), // placeholder
             info: info.get(),
-            attrs: attrs.clone(),
         });
+
+        self.base.push_port_attrs(new_port, attrs.clone());
 
         // Overwrite the value in the port map if any. This is okay because this
         // method can be called on local ports defined in iterative scopes.

--- a/crates/filament/src/ir_passes/mono/utils/comp.rs
+++ b/crates/filament/src/ir_passes/mono/utils/comp.rs
@@ -1,7 +1,9 @@
 use fil_ast as ast;
 use fil_ir::{
-    self as ir, AddCtx, Ctx, DisplayCtx, Idx, IndexStore, InterfaceSrc, MutCtx,
+    self as ir, AddCtx, Ctx, DenseIndexInfo, DisplayCtx, Idx, IndexStore,
+    InterfaceSrc, MutCtx,
 };
+use fil_utils as utils;
 
 use super::{Base, IntoBase, IntoUdl, Underlying};
 
@@ -24,6 +26,9 @@ impl<'a> UnderlyingComp<'a> {
     }
     pub fn ports(&self) -> &IndexStore<ir::Port> {
         self.0.ports()
+    }
+    pub fn port_attrs(&self) -> &DenseIndexInfo<ir::Port, utils::PortAttrs> {
+        &self.0.port_attrs
     }
     pub fn src_info(&self) -> &Option<InterfaceSrc> {
         &self.0.src_info
@@ -93,6 +98,14 @@ impl BaseComp {
     }
     pub fn set_src_info(&mut self, other: Option<InterfaceSrc>) {
         self.0.src_info = other;
+    }
+
+    pub fn push_port_attrs(
+        &mut self,
+        key: Base<ir::Port>,
+        val: utils::PortAttrs,
+    ) {
+        self.0.port_attrs.push(key.get(), val);
     }
 
     pub fn extend_cmds(

--- a/crates/ir/src/comp.rs
+++ b/crates/ir/src/comp.rs
@@ -4,7 +4,7 @@ use super::{
     InvIdx, Invoke, MutCtx, Param, ParamIdx, Port, PortIdx, Prop, PropIdx,
     Time, TimeSub,
 };
-use crate::{utils::Idx, ParamOwner};
+use crate::{utils::Idx, DenseIndexInfo, ParamOwner, SparseInfoMap};
 use fil_ast as ast;
 use fil_derive::Ctx;
 use fil_utils as utils;
@@ -59,6 +59,8 @@ pub struct Component {
     // ============== Component signature ===============
     /// Attributes of the component
     pub attrs: utils::CompAttrs,
+    /// Attributes of ports in the component
+    pub port_attrs: DenseIndexInfo<Port, utils::PortAttrs>,
     /// The input parameters to the component
     pub(crate) param_args: Box<[ParamIdx]>,
     /// The input events to the component

--- a/crates/ir/src/comp.rs
+++ b/crates/ir/src/comp.rs
@@ -4,7 +4,7 @@ use super::{
     InvIdx, Invoke, MutCtx, Param, ParamIdx, Port, PortIdx, Prop, PropIdx,
     Time, TimeSub,
 };
-use crate::{utils::Idx, DenseIndexInfo, ParamOwner, SparseInfoMap};
+use crate::{utils::Idx, DenseIndexInfo, ParamOwner};
 use fil_ast as ast;
 use fil_derive::Ctx;
 use fil_utils as utils;

--- a/crates/ir/src/from_ast/astconv.rs
+++ b/crates/ir/src/from_ast/astconv.rs
@@ -474,12 +474,13 @@ impl<'prog> BuildCtx<'prog> {
             owner,
             live,
             info,
-            attrs,
         };
 
         // Defines helper variable here due to lifetime issues
         let is_sig_port = p.is_sig();
         let idx = self.comp().add(p);
+        // Add the attributes to port attributes
+        self.comp().port_attrs.push(idx, attrs);
         // Fixup the liveness index parameter's owner
         let idxs = self.comp().get(idx).live.idxs.clone();
         for p in idxs {

--- a/crates/ir/src/from_ast/astconv.rs
+++ b/crates/ir/src/from_ast/astconv.rs
@@ -440,6 +440,7 @@ impl<'prog> BuildCtx<'prog> {
                     liveness,
                     bitwidth,
                 },
+            attrs,
         } = pd;
 
         let info = self.comp().add(ir::Info::port(
@@ -473,6 +474,7 @@ impl<'prog> BuildCtx<'prog> {
             owner,
             live,
             info,
+            attrs,
         };
 
         // Defines helper variable here due to lifetime issues

--- a/crates/ir/src/structure.rs
+++ b/crates/ir/src/structure.rs
@@ -3,6 +3,7 @@ use super::{
     InstIdx, InvIdx, ParamIdx, PortIdx, Subst, TimeIdx, TimeSub,
 };
 use fil_ast::Op;
+use fil_utils::PortAttrs;
 use itertools::Itertools;
 use std::fmt;
 
@@ -142,6 +143,7 @@ pub struct Port {
     pub width: ExprIdx,
     pub live: Liveness,
     pub info: InfoIdx,
+    pub attrs: PortAttrs,
 }
 impl Port {
     /// Check if this is an invoke defined port

--- a/crates/ir/src/structure.rs
+++ b/crates/ir/src/structure.rs
@@ -3,7 +3,6 @@ use super::{
     InstIdx, InvIdx, ParamIdx, PortIdx, Subst, TimeIdx, TimeSub,
 };
 use fil_ast::Op;
-use fil_utils::PortAttrs;
 use itertools::Itertools;
 use std::fmt;
 
@@ -143,7 +142,6 @@ pub struct Port {
     pub width: ExprIdx,
     pub live: Liveness,
     pub info: InfoIdx,
-    pub attrs: PortAttrs,
 }
 impl Port {
     /// Check if this is an invoke defined port

--- a/crates/utils/src/attr/mod.rs
+++ b/crates/utils/src/attr/mod.rs
@@ -6,6 +6,7 @@ mod types;
 pub use attributes::Attributes;
 pub use ctx::AttrCtx;
 pub use store::AttrStore;
-pub use types::comp_attrs::{
-    Attrs as CompAttrs, Bool as CompBool, Num as CompNum,
+pub use types::{
+    comp_attrs::{Attrs as CompAttrs, Bool as CompBool, Num as CompNum},
+    port_attrs::{Attrs as PortAttrs, Bool as PortBool, Num as PortNum},
 };

--- a/crates/utils/src/attr/types.rs
+++ b/crates/utils/src/attr/types.rs
@@ -13,3 +13,9 @@ attr_set! {
     numeric {
     };
 }
+
+attr_set! {
+    port_attrs;
+    flag {};
+    numeric {};
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -8,7 +8,10 @@ mod math;
 mod position;
 mod reporter;
 
-pub use attr::{AttrCtx, AttrStore, Attributes, CompAttrs, CompBool, CompNum};
+pub use attr::{
+    AttrCtx, AttrStore, Attributes, CompAttrs, CompBool, CompNum, PortAttrs,
+    PortBool, PortNum,
+};
 pub use errors::{Error, FilamentResult};
 pub use gsym::GSym;
 pub use id::Id;

--- a/crates/utils/src/macros.rs
+++ b/crates/utils/src/macros.rs
@@ -83,7 +83,7 @@ macro_rules! attr_enum {
           )*
       };
   ) => {
-      attr_enum! {
+      $crate::attr_enum! {
           enum $name;
           pub {};
           priv {


### PR DESCRIPTION
Adds port attributes of the form

```
#[attrib]
port: ['G, 'G+1] 32,
...
```

Also can technically be used within bundle definitions like
```
bundle #[attrib] bun[3]: for<i> ['G + i, 'G+i+1] 32;
```