### PR TITLE
Update link to tutorial in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Filament is a hardware description language (HDL) that uses a type system to specify and compose hardware pipelines.
 Filament reasons about the *timing* of a design, allowing the compiler to automatically generate pipelined designs with little to no overhead.
 
-Get started with Filament by reading the [tutorial](https://filamenthdl.com).
+Get started with Filament by reading the [tutorial](https://filamenthdl.com/docs/).
 
 Filament's design is based on the paper ["Modular Hardware Design with Timeline Types"][filament-paper] although it has evolved significantly since then.
 


### PR DESCRIPTION
The "tutorial" link actually links to the main website rather than the docs which have the tutorial.