### PR TITLE
Associate attributes to passes

### DIFF
--- a/crates/filament/src/ir_passes/bundle_elim.rs
+++ b/crates/filament/src/ir_passes/bundle_elim.rs
@@ -240,6 +240,10 @@ impl Visitor for BundleElim {
         "bundle-elim"
     }
 
+    fn flag() -> Option<utils::CompBool> {
+        Some(utils::CompBool::BundleLess)
+    }
+
     /// Compiles a connect command by breaking it into multiple simple connect commands
     /// Also eliminates local ports by storing their source bindings in the pass.
     fn connect(

--- a/crates/filament/src/ir_passes/mono/monomorphize.rs
+++ b/crates/filament/src/ir_passes/mono/monomorphize.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use fil_gen as gen;
 use fil_ir::{self as ir, Ctx, IndexStore};
+use fil_utils::{self as utils, AttrCtx};
 use ir::{AddCtx, EntryPoint};
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -255,12 +256,18 @@ impl<'ctx> Monomorphize<'ctx> {
 
         // the component whose signature we want to monomorphize
         // Monomorphize the sig
-        let mono_comp = MonoDeferred::new(
+        let mut mono_comp = MonoDeferred::new(
             UnderlyingComp::new(self.old.get(comp.idx())),
             self,
             monosig,
         )
         .comp();
+
+        mono_comp.attrs.set(
+            utils::CompBool::Monomorphic,
+            true,
+            utils::GPosIdx::UNKNOWN,
+        );
 
         let new_comp = self.ctx.add(mono_comp).base();
         self.processed.insert(n_ck, new_comp);

--- a/crates/filament/src/ir_visitor/visitor.rs
+++ b/crates/filament/src/ir_visitor/visitor.rs
@@ -1,5 +1,6 @@
 use crate::cmdline;
 use fil_ir::{self as ir, MutCtx};
+use fil_utils::{self as utils, AttrCtx, GPosIdx};
 
 #[must_use]
 #[derive(PartialEq, Eq)]
@@ -103,6 +104,12 @@ where
 {
     /// The user visible name for the pass
     fn name() -> &'static str;
+
+    /// Flag associated with this component
+    /// Used to track whether a component has been transformed by this pass
+    fn flag() -> Option<utils::CompBool> {
+        None
+    }
 
     #[must_use]
     /// Executed after the visitor has visited all the components.
@@ -295,6 +302,10 @@ where
             data.comp.cmds = pre_cmds;
         }
         data.comp.cmds.extend(cmds);
+
+        if let Some(flag) = Self::flag() {
+            data.comp.attrs.set(flag, true, GPosIdx::UNKNOWN);
+        }
 
         self.end(&mut data);
     }

--- a/crates/utils/src/attr/types.rs
+++ b/crates/utils/src/attr/types.rs
@@ -9,6 +9,12 @@ attr_set! {
             /// Use a counter based FSM design
             CounterFSM: "counter_fsm",
         };
+        priv {
+            /// This component is monomorphic
+            Monomorphic,
+            /// Bundles have been eliminated
+            BundleLess,
+        };
     };
     numeric {};
     float {};


### PR DESCRIPTION
Not sure if this is strictly necessary but with a lot of the work I am doing I need to have monomorphized components and it seems maybe a bit more explicit if we have attributes associated with these? 