### PR TITLE
Move assumption/assertion generation to its own pass

### DIFF
--- a/crates/filament/src/ir_passes/assumptions.rs
+++ b/crates/filament/src/ir_passes/assumptions.rs
@@ -1,0 +1,355 @@
+use crate::ir_visitor::{Action, Visitor, VisitorData};
+use fil_ast::{self as ast, Instance};
+use fil_ir::{self as ir, AddCtx, Ctx, DisplayCtx, Foldable, PropIdx};
+use fil_utils::GPosIdx;
+use itertools::Itertools;
+
+/// Generates default assumptions associated with
+/// well-formed programs.
+#[derive(Default)]
+pub struct Assumptions;
+
+impl Assumptions {
+    fn transfer_prop(
+        prop: ir::Foreign<ir::Prop, ir::Component>,
+        data: &mut VisitorData,
+        param_bind: &ir::Bind<
+            ir::Foreign<ir::Param, ir::Component>,
+            ir::ExprIdx,
+        >,
+        event_bind: &ir::Bind<
+            ir::Foreign<ir::Event, ir::Component>,
+            ir::TimeIdx,
+        >,
+    ) -> ir::PropIdx {
+        if prop.owner() == data.idx {
+            // The proposition is in the current component,
+            // use ir::Subst instead of transfer
+            let prop = prop.key();
+            prop.fold_with(&mut data.comp, &mut |param| {
+                param_bind.get(&ir::Foreign::new(param, data.idx)).copied()
+            })
+            .fold_with(&mut data.comp, &mut |event| {
+                event_bind.get(&ir::Foreign::new(event, data.idx)).copied()
+            })
+        } else {
+            // The proposition is in a different component
+            // Thus, we can use data.mut_ctx.get directly to get the component
+            prop.transfer_with(
+                &mut data.comp,
+                data.mut_ctx.get(prop.owner()),
+                param_bind,
+                event_bind,
+            )
+        }
+    }
+
+    /// Adds assumptions about the ports in the component
+    fn port_assumptions(&mut self, data: &mut VisitorData) -> Vec<ir::Command> {
+        let comp = &mut data.comp;
+        let mut cmds = Vec::with_capacity(comp.ports().len() * 2);
+        let ports = comp
+            .ports()
+            .iter()
+            .flat_map(|(_, p)| {
+                p.live.idxs.iter().copied().zip(p.live.lens.iter().copied())
+            })
+            .collect_vec();
+
+        // Add assumptions for range of bundle-bound indices
+        for (idx, len) in ports {
+            let ir::Param { info, .. } = comp.get(idx);
+            let bind_loc = if let Some(&ir::info::Param { bind_loc, .. }) =
+                comp.get(*info).into()
+            {
+                bind_loc
+            } else {
+                GPosIdx::UNKNOWN
+            };
+
+            let idx = idx.expr(comp);
+            let start = idx.gte(comp.num(0), comp);
+            let end = idx.lt(len, comp);
+            let in_range = start.and(end, comp);
+
+            let reason = comp.add(
+                ir::info::Reason::misc(
+                    "bundle index is within range",
+                    bind_loc,
+                )
+                .into(),
+            );
+
+            cmds.extend(comp.assume(in_range, reason))
+        }
+        cmds
+    }
+}
+
+impl Visitor for Assumptions {
+    fn name() -> &'static str {
+        "assumptions"
+    }
+
+    fn start(&mut self, data: &mut VisitorData) -> Action {
+        // Intern all signature-level parameter assumptions
+        let mut assumptions = Vec::new();
+
+        for (prop, loc) in data
+            .comp
+            .get_event_asserts()
+            .iter()
+            .chain(data.comp.get_param_asserts())
+            .copied()
+            .collect_vec()
+        {
+            let info = data.comp.add(ir::Info::assert(ir::info::Reason::misc(
+                "Signature assumption",
+                loc,
+            )));
+            assumptions.extend(data.comp.assume(prop, info))
+        }
+
+        // Add assumptions about the ports in the component
+        assumptions.extend(self.port_assumptions(data));
+
+        Action::AddBefore(assumptions)
+    }
+
+    fn instance(
+        &mut self,
+        inst: fil_ir::InstIdx,
+        data: &mut VisitorData,
+    ) -> Action {
+        let ir::Instance {
+            comp: foreign_idx,
+            args,
+            info,
+            params,
+            ..
+        } = data.comp.get(inst).clone();
+
+        let info = data.comp.get(info);
+        let comp_loc =
+            if let Some(&ir::info::Instance { comp_loc, .. }) = info.into() {
+                comp_loc
+            } else {
+                GPosIdx::UNKNOWN
+            };
+        let mut assumptions = Vec::new();
+
+        log::trace!(
+            "Transferring assumptions for instance {} from comp {} to {}",
+            data.comp.display(inst),
+            foreign_idx,
+            data.idx
+        );
+
+        let foreign_comp = data.get(foreign_idx);
+        let param_bind = foreign_comp
+            .param_args()
+            .iter()
+            .copied()
+            .chain(foreign_comp.exist_params())
+            .map(|param| ir::Foreign::new(param, foreign_idx))
+            .collect_vec();
+
+        // We need to do this separately to avoid borrowing data.comp mutably while it is immutably borrowed.
+        let param_args = args
+            .into_iter()
+            .chain(params.into_iter().map(|param| param.expr(&mut data.comp)))
+            .collect_vec();
+        let param_bind = ir::Bind::new(
+            param_bind.into_iter().zip(param_args).collect::<Vec<_>>(),
+        );
+
+        let param_asserts = data
+            .get(foreign_idx)
+            .get_param_asserts()
+            .iter()
+            .copied()
+            .collect_vec();
+
+        // Intern all instance-level param assertions in the foreign component
+        // as assertions that need to be proved for the current component.
+        for (prop, loc) in param_asserts {
+            log::trace!(
+                "Transferring parameter assumption {} from {} to {}",
+                data.get(foreign_idx).display(prop),
+                foreign_idx,
+                data.idx
+            );
+
+            let prop = ir::Foreign::new(prop, foreign_idx);
+
+            let new_prop = Assumptions::transfer_prop(prop, data, &param_bind);
+
+            let info = data.comp.add(ir::Info::assert(
+                ir::info::Reason::param_cons(comp_loc, loc),
+            ));
+
+            assumptions.extend(data.comp.assert(new_prop, info))
+        }
+
+        let exist_assumes = data.get(foreign_idx).all_exist_assumes();
+
+        // Existential assumptions in the foreign component become
+        // assumptions in the current component.
+        for (prop, loc) in exist_assumes {
+            log::trace!(
+                "Transferring existential assumption {} from {} to {}",
+                data.get(foreign_idx).display(prop),
+                foreign_idx,
+                data.idx
+            );
+
+            let prop = ir::Foreign::new(prop, foreign_idx);
+
+            let new_prop = Assumptions::transfer_prop(prop, data, &param_bind);
+
+            let info = data.comp.add(ir::Info::assert(
+                ir::info::Reason::exist_cons(comp_loc, Some(loc)),
+            ));
+
+            assumptions.extend(data.comp.assume(new_prop, info))
+        }
+
+        Action::AddBefore(assumptions)
+    }
+
+    fn invoke(
+        &mut self,
+        inv: fil_ir::InvIdx,
+        data: &mut VisitorData,
+    ) -> Action {
+        let ir::Invoke {
+            inst,
+            events,
+            ports,
+            info,
+        } = data.comp.get(inv).clone();
+
+        let foreign_idx = inv.comp(&data.comp);
+
+        let info: &fil_ir::Info = data.comp.get(info);
+        let inst_loc =
+            if let Some(&ir::info::Invoke { inst_loc, .. }) = info.into() {
+                inst_loc
+            } else {
+                GPosIdx::UNKNOWN
+            };
+        let mut assumptions = Vec::new();
+
+        log::trace!(
+            "Transferring assumptions for invoke {} from comp {} to {}",
+            data.comp.display(inv),
+            foreign_idx,
+            data.idx
+        );
+
+        let foreign_comp = data.get(foreign_idx);
+        let event_bind = ir::Bind::new(events.into_iter().map(
+            |ir::EventBind {
+                 delay,
+                 arg,
+                 info,
+                 base,
+             }| { (base, arg) },
+        ));
+        // We need to do this separately to avoid borrowing data.comp mutably while it is immutably borrowed.
+        let event_asserts = data
+            .get(foreign_idx)
+            .get_event_asserts()
+            .iter()
+            .copied()
+            .collect_vec();
+
+        // Intern all instance-level param assertions in the foreign component
+        // as assertions that need to be proved for the current component.
+        for (prop, loc) in event_asserts {
+            log::trace!(
+                "Transferring event assertion {} from {} to {}",
+                data.get(foreign_idx).display(prop),
+                foreign_idx,
+                data.idx
+            );
+
+            let prop = ir::Foreign::new(prop, foreign_idx);
+
+            let new_prop = Assumptions::transfer_prop(
+                prop,
+                data,
+                &Bind::new(None),
+                &event_bind,
+            );
+
+            let info = data.comp.add(ir::Info::assert(
+                ir::info::Reason::param_cons(comp_loc, loc),
+            ));
+
+            assumptions.extend(data.comp.assert(new_prop, info))
+        }
+
+        let exist_assumes = data.get(foreign_idx).all_exist_assumes();
+
+        // Existential assumptions in the foreign component become
+        // assumptions in the current component.
+        for (prop, loc) in exist_assumes {
+            log::trace!(
+                "Transferring existential assumption {} from {} to {}",
+                data.get(foreign_idx).display(prop),
+                foreign_idx,
+                data.idx
+            );
+
+            let prop = ir::Foreign::new(prop, foreign_idx);
+
+            let new_prop = Assumptions::transfer_prop(prop, data, &param_bind);
+
+            let info = data.comp.add(ir::Info::assert(
+                ir::info::Reason::exist_cons(comp_loc, Some(loc)),
+            ));
+
+            assumptions.extend(data.comp.assume(new_prop, info))
+        }
+
+        Action::AddBefore(assumptions)
+    }
+
+    fn start_loop(
+        &mut self,
+        l: &mut fil_ir::Loop,
+        data: &mut VisitorData,
+    ) -> Action {
+        let comp = &mut data.comp;
+
+        let ir::Loop {
+            index, start, end, ..
+        } = l;
+
+        let start = *start;
+        let end = *end;
+        let index = *index;
+        let ir::Param { info, .. } = comp.get(index);
+        let bind_loc = if let Some(&ir::info::Param { bind_loc, .. }) =
+            comp.get(*info).into()
+        {
+            bind_loc
+        } else {
+            GPosIdx::UNKNOWN
+        };
+        let index = index.expr(comp);
+
+        // Add the assumption that the index is within bounds
+        let idx_start = index.gte(start, comp);
+        let idx_end = index.lt(end, comp);
+        let in_range = idx_start.and(idx_end, comp);
+
+        let info = comp.add(
+            ir::info::Reason::misc("loop index is within range", bind_loc)
+                .into(),
+        );
+
+        Action::AddBefore(vec![comp.assume(in_range, info).unwrap()])
+    }
+}

--- a/crates/filament/src/ir_passes/fun_assumptions.rs
+++ b/crates/filament/src/ir_passes/fun_assumptions.rs
@@ -4,9 +4,9 @@ use fil_ir::{self as ir, AddCtx, Ctx, ExprIdx, PropIdx};
 
 /// Generates default assumptions to the Filament program for assumptions using custom functions
 #[derive(Default)]
-pub struct Assume;
+pub struct FunAssumptions;
 
-impl Assume {
+impl FunAssumptions {
     /// Adds the assumptions associated with a proposition of the form `#l = f(#r)` to the component.
     fn add_assumptions(
         ctx: &mut ir::Component,
@@ -56,7 +56,7 @@ impl Assume {
     }
 }
 
-impl Assume {
+impl FunAssumptions {
     /// Checks a proposition for whether it matches the form `#l = f(#r)` for some custom function `f`. Additionally recurses on `&` chains.
     /// Generates the assumptions associated with each [ast::Fn] and returns a list of [ir::Prop]s for each.
     /// TODO: Implement assumption generation for functions taking more than one argument.
@@ -103,9 +103,9 @@ impl Assume {
             // Recurse on both the left and right subexpressions if the proposition is of the form `l & r`
             ir::Prop::And(lhs, rhs) => {
                 let (lhs, rhs) = (*lhs, *rhs);
-                Assume::prop(lhs, comp)
+                Self::prop(lhs, comp)
                     .into_iter()
-                    .chain(Assume::prop(rhs, comp))
+                    .chain(Self::prop(rhs, comp))
                     .collect()
             }
             _ => vec![],
@@ -113,15 +113,15 @@ impl Assume {
     }
 }
 
-impl Visitor for Assume {
+impl Visitor for FunAssumptions {
     fn name() -> &'static str {
-        "add-assume"
+        "fun-assumptions"
     }
 
     fn fact(&mut self, f: &mut ir::Fact, data: &mut VisitorData) -> Action {
         if f.is_assume() {
             Action::AddBefore(
-                Assume::prop(f.prop, &mut data.comp)
+                Self::prop(f.prop, &mut data.comp)
                     .into_iter()
                     .filter_map(|prop| data.comp.assume(prop, f.reason))
                     .collect(),

--- a/crates/filament/src/ir_passes/interval_check.rs
+++ b/crates/filament/src/ir_passes/interval_check.rs
@@ -130,7 +130,7 @@ impl Visitor for IntervalCheck {
         let assumes = comp
             .all_exist_assumes()
             .into_iter()
-            .fold(init, |a, b| a.and(b, comp));
+            .fold(init, |a, (b, _)| a.and(b, comp));
 
         // Ensure that delays are greater than zero
         let mut cmds: Vec<ir::Command> =

--- a/crates/filament/src/ir_passes/mod.rs
+++ b/crates/filament/src/ir_passes/mod.rs
@@ -1,10 +1,11 @@
 mod assignment_check;
-mod assume;
+mod assumptions;
 mod build_domination;
 mod bundle_elim;
 mod discharge;
 mod dump_interface;
 mod fsm_attributes;
+mod fun_assumptions;
 mod interval_check;
 mod lower;
 mod mono;
@@ -13,12 +14,13 @@ mod prop_simplify;
 mod type_check;
 
 pub use assignment_check::AssignCheck;
-pub use assume::Assume;
+pub use assumptions::Assumptions;
 pub use build_domination::BuildDomination;
 pub use bundle_elim::BundleElim;
 pub use discharge::Discharge;
 pub use dump_interface::DumpInterface;
 pub use fsm_attributes::FSMAttributes;
+pub use fun_assumptions::FunAssumptions;
 pub use interval_check::IntervalCheck;
 pub use lower::Compile;
 pub use mono::Monomorphize;

--- a/crates/filament/src/ir_passes/mono/monodeferred.rs
+++ b/crates/filament/src/ir_passes/mono/monodeferred.rs
@@ -110,7 +110,7 @@ impl MonoDeferred<'_, '_> {
         // The type checker ensures this cannot happen for Filament-level
         // components but externally generated components might violate their
         // requirements.
-        for prop in self.underlying.all_exist_assumes() {
+        for (prop, _) in self.underlying.all_exist_assumes() {
             let out = self.monosig.prop(&self.underlying, prop.ul(), self.pass);
             let Some(v) = out.get().as_concrete(self.monosig.base.comp())
             else {

--- a/crates/filament/src/ir_passes/mono/utils/comp.rs
+++ b/crates/filament/src/ir_passes/mono/utils/comp.rs
@@ -39,7 +39,7 @@ impl<'a> UnderlyingComp<'a> {
     pub fn exist_params(&self) -> impl Iterator<Item = ir::ParamIdx> + '_ {
         self.0.exist_params()
     }
-    pub fn all_exist_assumes(&self) -> Vec<ir::PropIdx> {
+    pub fn all_exist_assumes(&self) -> Vec<(ir::PropIdx, utils::GPosIdx)> {
         self.0.all_exist_assumes()
     }
     pub fn relevant_vars(

--- a/crates/filament/src/ir_passes/type_check.rs
+++ b/crates/filament/src/ir_passes/type_check.rs
@@ -91,7 +91,7 @@ impl Visitor for TypeCheck {
         Action::AddBefore(
             assumes
                 .iter()
-                .flat_map(|p| data.comp.assert(*p, info))
+                .flat_map(|(p, _)| data.comp.assert(*p, info))
                 .collect_vec(),
         )
     }

--- a/crates/filament/src/ir_visitor/visitor.rs
+++ b/crates/filament/src/ir_visitor/visitor.rs
@@ -1,5 +1,5 @@
 use crate::cmdline;
-use fil_ir::{self as ir, MutCtx};
+use fil_ir::{self as ir, Ctx, MutCtx};
 
 #[must_use]
 #[derive(PartialEq, Eq)]
@@ -48,6 +48,17 @@ impl<'comp> VisitorData<'comp> {
     /// Get an immutable reference to the current [ir::Context].
     pub fn ctx(&'comp self) -> &'comp ir::Context {
         self.mut_ctx
+    }
+    /// Get an immutable reference to a component.
+    /// This is necessary because if the component being borrowed
+    /// is exactly the same as the one being visited,
+    /// the context no longer contains it.
+    pub fn get(&self, idx: ir::CompIdx) -> &ir::Component {
+        if idx == self.idx {
+            &self.comp
+        } else {
+            self.mut_ctx.get(idx)
+        }
     }
 }
 

--- a/crates/filament/src/main.rs
+++ b/crates/filament/src/main.rs
@@ -77,11 +77,12 @@ fn run(opts: &cmdline::Opts) -> Result<(), u64> {
     // Transform AST to IR
     let mut ir = log_pass! { opts; ir::transform(ns)?, "astconv" };
     ir_pass_pipeline! {opts, ir;
+        ip::Assumptions,
         ip::BuildDomination,
         ip::TypeCheck,
         ip::IntervalCheck,
         ip::PhantomCheck,
-        ip::Assume
+        ip::FunAssumptions
     }
     if !opts.unsafe_skip_discharge {
         ir_pass_pipeline! {opts, ir; ip::Discharge }
@@ -99,11 +100,12 @@ fn run(opts: &cmdline::Opts) -> Result<(), u64> {
     }
     // type check again before lowering
     ir_pass_pipeline! {opts, ir;
+        ip::Assumptions,
         ip::BuildDomination,
         ip::TypeCheck,
         ip::IntervalCheck,
         ip::PhantomCheck,
-        ip::Assume
+        ip::FunAssumptions
     }
     if !opts.unsafe_skip_discharge {
         ir_pass_pipeline! {opts, ir; ip::Discharge }

--- a/crates/ir/src/fact.rs
+++ b/crates/ir/src/fact.rs
@@ -4,7 +4,7 @@ use super::{
 use crate::{Event, EventIdx, Expr, Param, ParamIdx, Time, construct_binop};
 use std::fmt::{self, Display};
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// Comparison operators
 pub enum Cmp {
     Gt,

--- a/crates/ir/src/from_ast/astconv.rs
+++ b/crates/ir/src/from_ast/astconv.rs
@@ -575,11 +575,6 @@ impl BuildCtx<'_> {
     fn sig(&mut self, idx: ir::CompIdx, sig: &ast::Signature) -> BuildRes<Sig> {
         let mut conv_sig = Sig::new(idx, sig);
 
-        // Constraints defined in the signature of the component
-        let mut sig_cons: Vec<ir::Command> = Vec::with_capacity(
-            sig.param_constraints.len() + sig.event_constraints.len(),
-        );
-
         // Add parameters to the component
         self.comp().param_args = sig
             .params
@@ -611,7 +606,10 @@ impl BuildCtx<'_> {
                         // Constraints on existentially quantified parameters
                         let assumes = cons
                             .iter()
-                            .map(|pc| self.expr_cons(pc.inner().clone()))
+                            .map(|pc| {
+                                self.expr_cons(pc.inner().clone())
+                                    .map(|p| (p, pc.pos()))
+                            })
                             .collect::<BuildRes<Vec<_>>>()?;
                         self.comp().add_exist_assumes(p_idx, assumes);
                         Ok((sb.inner().clone(), Some(p_idx)))
@@ -662,72 +660,20 @@ impl BuildCtx<'_> {
         }
         // Constraints defined by the signature
         for ec in &sig.event_constraints {
-            let info = self.comp().add(ir::Info::assert(
-                ir::info::Reason::misc("Signature assumption", ec.pos()),
-            ));
             let prop = self.event_cons(ec.inner().clone())?;
-            sig_cons.extend(self.comp().assume(prop, info));
-            self.comp().add_event_assert([prop]);
+            self.comp().add_event_assert([(prop, ec.pos())]);
         }
         for pc in &sig.param_constraints {
-            let info = self.comp().add(ir::Info::assert(
-                ir::info::Reason::misc("Signature assumption", pc.pos()),
-            ));
             let prop = self.expr_cons(pc.inner().clone())?;
-            sig_cons.extend(self.comp().assume(prop, info));
-            self.comp().add_param_assert([prop]);
+            self.comp().add_param_assert([(prop, pc.pos())]);
         }
-
-        self.comp().cmds.extend(sig_cons);
 
         Ok(conv_sig)
     }
 
     fn instance(&mut self, inst: ast::Instance) -> BuildRes<Vec<ir::Command>> {
-        let comp_loc = inst.component.pos();
-        // Add the facts defined by the instance as assertions in the
-        // component.
         let idx = self.get_inst(&inst.name)?;
-        let (binding, component) = self.inst_to_sig.get(idx).clone();
-        let sig = self.get_sig(&component)?;
-        let asserts = sig
-            .param_cons
-            .clone()
-            .into_iter()
-            .map(|f| {
-                let reason = self.comp().add(
-                    ir::info::Reason::param_cons(comp_loc, f.pos()).into(),
-                );
-                let p = f.take().resolve_expr(&binding);
-                // This is a checked fact because the calling component needs to
-                // honor it.
-                self.expr_cons(p).map(|p| self.comp().assert(p, reason))
-            })
-            .collect::<BuildRes<Vec<_>>>()?
-            .into_iter()
-            .flatten();
-
-        let assumes = sig
-            .exist_cons
-            .clone()
-            .into_iter()
-            .map(|f| {
-                let reason = self.comp().add(
-                    ir::info::Reason::exist_cons(comp_loc, Some(f.pos()))
-                        .into(),
-                );
-                let p = f.take().resolve_expr(&binding);
-                // This is an assumption because the called component guarantees guarantees it.
-                self.expr_cons(p).map(|p| self.comp().assume(p, reason))
-            })
-            .collect::<BuildRes<Vec<_>>>()?
-            .into_iter()
-            .flatten();
-
-        Ok(iter::once(ir::Command::from(idx))
-            .chain(asserts)
-            .chain(assumes)
-            .collect_vec())
+        Ok(vec![ir::Command::from(idx)])
     }
 
     /// This function is called during the second pass of the conversion and does the following:
@@ -963,34 +909,22 @@ impl BuildCtx<'_> {
             }) => {
                 let start = self.expr(start)?;
                 let end = self.expr(end)?;
-                // Assumption that the index is within range
-                let reason = self.comp().add(
-                    ir::info::Reason::misc(
-                        "loop index is within range",
-                        idx.pos(),
-                    )
-                    .into(),
-                );
 
                 // Compile the body in a new scope
                 let (index, body) = self.try_with_scope(|this| {
                     let idx = this.param(idx, ir::ParamOwner::Loop);
                     Ok((idx, this.commands(body)?))
                 })?;
-                let l = ir::Loop {
-                    index,
-                    start,
-                    end,
-                    body,
-                }
-                .into();
-                let index = index.expr(self.comp());
-                let idx_start = index.gte(start, self.comp());
-                let idx_end = index.lt(end, self.comp());
-                let in_range = idx_start.and(idx_end, self.comp());
-                iter::once(l)
-                    .chain(self.comp().assume(in_range, reason))
-                    .collect()
+
+                vec![
+                    ir::Loop {
+                        index,
+                        start,
+                        end,
+                        body,
+                    }
+                    .into(),
+                ]
             }
             ast::Command::If(ast::If { cond, then, alt }) => {
                 let cond = self.expr_cons(cond)?;
@@ -1005,37 +939,6 @@ impl BuildCtx<'_> {
             }
         };
         Ok(cmds)
-    }
-
-    /// Adds assumptions about the ports in the component
-    fn port_assumptions(&mut self) -> Vec<ir::Command> {
-        let mut cmds = Vec::with_capacity(self.comp().ports().len() * 2);
-        let ports = self
-            .comp()
-            .ports()
-            .iter()
-            .flat_map(|(_, p)| {
-                p.live.idxs.iter().copied().zip(p.live.lens.iter().copied())
-            })
-            .collect_vec();
-
-        // Add assumptions for range of bundle-bound indices
-        let reason = self.comp().add(
-            ir::info::Reason::misc(
-                "bundle index is within range",
-                GPosIdx::UNKNOWN,
-            )
-            .into(),
-        );
-
-        for (idx, len) in ports {
-            let idx = idx.expr(self.comp());
-            let start = idx.gte(self.comp().num(0), self.comp());
-            let end = idx.lt(len, self.comp());
-            let in_range = start.and(end, self.comp());
-            cmds.extend(self.comp().assume(in_range, reason))
-        }
-        cmds
     }
 }
 
@@ -1252,9 +1155,7 @@ fn try_transform(ns: ast::Namespace) -> BuildRes<ir::Context> {
             Some(cmds) => builder.commands(cmds)?,
             None => vec![],
         };
-        let mut cmds = builder.port_assumptions();
-        cmds.extend(body_cmds);
-        builder.comp().cmds.extend(cmds);
+        builder.comp().cmds.extend(body_cmds);
         log::debug!("Adding component: {}", idx);
         ctx.comps.checked_add(idx, builder.take())
     }

--- a/crates/ir/src/from_ast/astconv.rs
+++ b/crates/ir/src/from_ast/astconv.rs
@@ -719,25 +719,6 @@ impl BuildCtx<'_> {
             .map(|p| p.try_map(|p| self.get_access(p, ir::Direction::Out)))
             .collect::<BuildRes<Vec<_>>>()?;
 
-        // Constraints on the events from the signature
-        let cons: Vec<ir::Command> = sig
-            .event_cons
-            .clone()
-            .into_iter()
-            .map(|ec| {
-                let reason = self.comp().add(
-                    ir::info::Reason::event_cons(instance.pos(), ec.pos())
-                        .into(),
-                );
-                let ec = ec.take().resolve_event(&event_binding);
-                self.event_cons(ec)
-                    .map(|prop| self.comp().assert(prop, reason))
-            })
-            .collect::<BuildRes<Vec<_>>>()?
-            .into_iter()
-            .flatten()
-            .collect();
-
         let mut connects = Vec::with_capacity(sig.inputs.len());
 
         for ((p, idx), src) in sig.inputs.clone().into_iter().zip(srcs) {
@@ -818,7 +799,6 @@ impl BuildCtx<'_> {
 
         Ok(std::iter::once(ir::Command::from(inv))
             .chain(connects)
-            .chain(cons)
             .collect_vec())
     }
 

--- a/crates/ir/src/from_ast/sig_map.rs
+++ b/crates/ir/src/from_ast/sig_map.rs
@@ -24,12 +24,6 @@ pub struct Sig {
     pub raw_params: Vec<ast::ParamBind>,
     /// The AST representation of events in the signature
     pub raw_events: Vec<ast::EventBind>,
-    /// Constraints on input parameters
-    pub param_cons: Vec<ast::Loc<ast::OrderConstraint<ast::Expr>>>,
-    /// Constraints on existentially bound parameters
-    pub exist_cons: Vec<ast::Loc<ast::OrderConstraint<ast::Expr>>>,
-    /// Constraints on events
-    pub event_cons: Vec<ast::Loc<ast::OrderConstraint<ast::Time>>>,
 }
 
 impl Sig {
@@ -38,16 +32,6 @@ impl Sig {
             idx,
             raw_params: sig.params.iter().map(|p| p.clone().take()).collect(),
             raw_events: sig.events.iter().map(|e| e.clone().take()).collect(),
-            param_cons: sig.param_constraints.clone(),
-            exist_cons: sig
-                .sig_bindings
-                .iter()
-                .flat_map(|sb| match &sb.inner() {
-                    ast::SigBind::Exists { cons, .. } => cons.clone(),
-                    ast::SigBind::Let { .. } => vec![],
-                })
-                .collect(),
-            event_cons: sig.event_constraints.clone(),
             // Filled in later
             sig_binding: Vec::default(),
             inputs: Vec::default(),

--- a/crates/ir/src/printer/comp.rs
+++ b/crates/ir/src/printer/comp.rs
@@ -216,8 +216,10 @@ impl<'a, 'b> Printer<'a, 'b> {
                 indent = indent + 2
             )?;
             if let Some(assumes) = self.comp.get_exist_assumes(param) {
-                let props =
-                    assumes.iter().map(|p| self.comp.display(*p)).join(", ");
+                let props = assumes
+                    .iter()
+                    .map(|(p, _)| self.comp.display(*p))
+                    .join(", ");
                 writeln!(f, " where {props};")?;
             } else {
                 writeln!(f, ";")?;
@@ -229,7 +231,7 @@ impl<'a, 'b> Printer<'a, 'b> {
 
         if !p_asserts.is_empty() || !e_asserts.is_empty() {
             writeln!(f, "}} where ")?;
-            for idx in p_asserts.iter().chain(e_asserts.iter()) {
+            for (idx, _) in p_asserts.iter().chain(e_asserts.iter()) {
                 write!(f, "{:indent$}", "", indent = indent + 2)?;
                 self.comp.write(*idx, f)?;
                 writeln!(f, ",")?;

--- a/crates/ir/src/time.rs
+++ b/crates/ir/src/time.rs
@@ -115,3 +115,20 @@ impl Foldable<ParamIdx, ExprIdx> for TimeSub {
         }
     }
 }
+
+impl Foldable<EventIdx, TimeIdx> for TimeSub {
+    type Context = Component;
+
+    fn fold_with<F>(&self, ctx: &mut Self::Context, subst_fn: &mut F) -> Self
+    where
+        F: FnMut(EventIdx) -> Option<TimeIdx>,
+    {
+        match self {
+            TimeSub::Unit(e) => TimeSub::Unit(e.fold_with(ctx, subst_fn)),
+            TimeSub::Sym { l, r } => TimeSub::Sym {
+                l: l.fold_with(ctx, subst_fn),
+                r: r.fold_with(ctx, subst_fn),
+            },
+        }
+    }
+}

--- a/crates/ir/src/utils/mod.rs
+++ b/crates/ir/src/utils/mod.rs
@@ -5,6 +5,7 @@ mod index_store;
 mod interned;
 mod sparse_info;
 mod subst;
+mod transfer;
 mod traversal;
 
 pub use dense_info::DenseIndexInfo;

--- a/crates/ir/src/utils/subst.rs
+++ b/crates/ir/src/utils/subst.rs
@@ -242,6 +242,84 @@ impl Foldable<ParamIdx, ExprIdx> for PropIdx {
     }
 }
 
+impl Foldable<EventIdx, TimeIdx> for ExprIdx {
+    type Context = Component;
+
+    fn fold_with<F>(&self, ctx: &mut Self::Context, subst_fn: &mut F) -> Self
+    where
+        F: FnMut(EventIdx) -> Option<TimeIdx>,
+    {
+        match ctx.get(*self).clone() {
+            Expr::Param(_) | Expr::Concrete(_) => *self,
+            Expr::Bin { op, lhs, rhs } => {
+                let lhs = lhs.fold_with(ctx, subst_fn);
+                let rhs = rhs.fold_with(ctx, subst_fn);
+                ctx.add(Expr::Bin { op, lhs, rhs })
+            }
+            Expr::Fn { op, args } => {
+                let args = args
+                    .iter()
+                    .map(|arg| arg.fold_with(ctx, subst_fn))
+                    .collect();
+                ctx.add(Expr::Fn { op, args })
+            }
+            Expr::If { cond, then, alt } => {
+                let cond = cond.fold_with(ctx, subst_fn);
+                let then = then.fold_with(ctx, subst_fn);
+                let alt = alt.fold_with(ctx, subst_fn);
+                ctx.add(Expr::If { cond, then, alt })
+            }
+        }
+    }
+}
+
+impl Foldable<EventIdx, TimeIdx> for PropIdx {
+    type Context = Component;
+
+    fn fold_with<F>(&self, ctx: &mut Self::Context, subst_fn: &mut F) -> Self
+    where
+        F: FnMut(EventIdx) -> Option<TimeIdx>,
+    {
+        match ctx.get(*self).clone() {
+            Prop::True | Prop::False => *self,
+            Prop::Cmp(CmpOp { op, lhs, rhs }) => {
+                let lhs = lhs.fold_with(ctx, subst_fn);
+                let rhs = rhs.fold_with(ctx, subst_fn);
+                ctx.add(Prop::Cmp(CmpOp { op, lhs, rhs }))
+            }
+            Prop::TimeCmp(CmpOp { op, lhs, rhs }) => {
+                let lhs = lhs.fold_with(ctx, subst_fn);
+                let rhs = rhs.fold_with(ctx, subst_fn);
+                ctx.add(Prop::TimeCmp(CmpOp { op, lhs, rhs }))
+            }
+            Prop::TimeSubCmp(CmpOp { op, lhs, rhs }) => {
+                let lhs = lhs.fold_with(ctx, subst_fn);
+                let rhs = rhs.fold_with(ctx, subst_fn);
+                ctx.add(Prop::TimeSubCmp(CmpOp { op, lhs, rhs }))
+            }
+            Prop::Not(p) => {
+                let p = p.fold_with(ctx, subst_fn);
+                p.not(ctx)
+            }
+            Prop::And(l, r) => {
+                let l = l.fold_with(ctx, subst_fn);
+                let r = r.fold_with(ctx, subst_fn);
+                l.and(r, ctx)
+            }
+            Prop::Or(l, r) => {
+                let l = l.fold_with(ctx, subst_fn);
+                let r = r.fold_with(ctx, subst_fn);
+                l.or(r, ctx)
+            }
+            Prop::Implies(a, c) => {
+                let a = a.fold_with(ctx, subst_fn);
+                let c = c.fold_with(ctx, subst_fn);
+                a.implies(c, ctx)
+            }
+        }
+    }
+}
+
 impl Foldable<EventIdx, TimeIdx> for TimeIdx {
     type Context = Component;
 

--- a/crates/ir/src/utils/transfer.rs
+++ b/crates/ir/src/utils/transfer.rs
@@ -1,7 +1,7 @@
 use super::{Bind, Foreign};
 use crate::{
-    AddCtx, CmpOp, Component, Ctx, Event, Expr, ExprIdx, MutCtx, Param, Prop,
-    PropIdx, Time, TimeIdx, TimeSub,
+    AddCtx, CmpOp, Ctx, Event, Expr, ExprIdx, MutCtx, Param, Prop, PropIdx,
+    Time, TimeIdx, TimeSub,
 };
 
 impl<C> Foreign<Expr, C>

--- a/crates/ir/src/utils/transfer.rs
+++ b/crates/ir/src/utils/transfer.rs
@@ -1,0 +1,206 @@
+use super::{Bind, Foreign};
+use crate::{
+    AddCtx, CmpOp, Component, Ctx, Event, Expr, ExprIdx, MutCtx, Param, Prop,
+    PropIdx, Time, TimeIdx, TimeSub,
+};
+
+impl<C> Foreign<Expr, C>
+where
+    C: Ctx<Time>
+        + Ctx<Expr>
+        + Ctx<Prop>
+        + Ctx<Param>
+        + Ctx<Event>
+        + AddCtx<Time>
+        + AddCtx<Prop>
+        + AddCtx<Expr>
+        + MutCtx<Param>,
+{
+    pub fn transfer_with(
+        &self,
+        wctx: &mut C,
+        rctx: &C,
+        param_bind: &Bind<Foreign<Param, C>, ExprIdx>,
+        event_bind: &Bind<Foreign<Event, C>, TimeIdx>,
+    ) -> ExprIdx {
+        let (e, owner) = self.take();
+        match rctx.get(e) {
+            Expr::Param(idx) => {
+                let idx = Foreign::new(*idx, owner);
+                *param_bind.get(&idx).unwrap()
+            }
+            Expr::Concrete(e) => wctx.add(Expr::Concrete(*e)),
+            Expr::Bin { op, lhs, rhs } => {
+                let lhs = Foreign::new(*lhs, owner);
+                let rhs = Foreign::new(*rhs, owner);
+                let lhs = lhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                let rhs = rhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                wctx.add(Expr::Bin { op: *op, lhs, rhs })
+            }
+            Expr::Fn { op, args } => {
+                let args = args
+                    .iter()
+                    .map(|arg| {
+                        let arg = Foreign::new(*arg, owner);
+                        arg.transfer_with(wctx, rctx, param_bind, event_bind)
+                    })
+                    .collect();
+                wctx.add(Expr::Fn { op: *op, args })
+            }
+            Expr::If { cond, then, alt } => {
+                let cond = Foreign::new(*cond, owner);
+                let then = Foreign::new(*then, owner);
+                let alt = Foreign::new(*alt, owner);
+                let cond =
+                    cond.transfer_with(wctx, rctx, param_bind, event_bind);
+                let then =
+                    then.transfer_with(wctx, rctx, param_bind, event_bind);
+                let alt = alt.transfer_with(wctx, rctx, param_bind, event_bind);
+                wctx.add(Expr::If { cond, then, alt })
+            }
+        }
+    }
+}
+
+impl<C> Foreign<Prop, C>
+where
+    C: Ctx<Time>
+        + Ctx<Expr>
+        + Ctx<Prop>
+        + Ctx<Param>
+        + Ctx<Event>
+        + AddCtx<Time>
+        + AddCtx<Prop>
+        + AddCtx<Expr>
+        + MutCtx<Param>,
+{
+    pub fn transfer_with(
+        &self,
+        wctx: &mut C,
+        rctx: &C,
+        param_bind: &Bind<Foreign<Param, C>, ExprIdx>,
+        event_bind: &Bind<Foreign<Event, C>, TimeIdx>,
+    ) -> PropIdx {
+        let (e, owner) = self.take();
+        match rctx.get(e) {
+            prop @ (Prop::True | Prop::False) => wctx.add(prop.clone()),
+            Prop::Cmp(CmpOp { op, lhs, rhs }) => {
+                let lhs = Foreign::new(*lhs, owner);
+                let rhs = Foreign::new(*rhs, owner);
+                let lhs = lhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                let rhs = rhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                wctx.add(Prop::Cmp(CmpOp { op: *op, lhs, rhs }))
+            }
+            Prop::TimeCmp(CmpOp { op, lhs, rhs }) => {
+                let lhs = Foreign::new(*lhs, owner);
+                let rhs = Foreign::new(*rhs, owner);
+                let lhs = lhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                let rhs = rhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                wctx.add(Prop::TimeCmp(CmpOp { op: *op, lhs, rhs }))
+            }
+            Prop::TimeSubCmp(CmpOp { op, lhs, rhs }) => {
+                let lhs = match lhs {
+                    TimeSub::Unit(lhs) => {
+                        let lhs = Foreign::new(*lhs, owner);
+                        let lhs = lhs
+                            .transfer_with(wctx, rctx, param_bind, event_bind);
+                        TimeSub::Unit(lhs)
+                    }
+                    TimeSub::Sym { l, r } => {
+                        let l = Foreign::new(*l, owner);
+                        let r = Foreign::new(*r, owner);
+                        let l =
+                            l.transfer_with(wctx, rctx, param_bind, event_bind);
+                        let r =
+                            r.transfer_with(wctx, rctx, param_bind, event_bind);
+                        TimeSub::Sym { l, r }
+                    }
+                };
+
+                let rhs = match rhs {
+                    TimeSub::Unit(rhs) => {
+                        let rhs = Foreign::new(*rhs, owner);
+                        let rhs = rhs
+                            .transfer_with(wctx, rctx, param_bind, event_bind);
+                        TimeSub::Unit(rhs)
+                    }
+                    TimeSub::Sym { l, r } => {
+                        let l = Foreign::new(*l, owner);
+                        let r = Foreign::new(*r, owner);
+                        let l =
+                            l.transfer_with(wctx, rctx, param_bind, event_bind);
+                        let r =
+                            r.transfer_with(wctx, rctx, param_bind, event_bind);
+                        TimeSub::Sym { l, r }
+                    }
+                };
+
+                wctx.add(Prop::TimeSubCmp(CmpOp { op: *op, lhs, rhs }))
+            }
+            Prop::Not(idx) => {
+                let idx = Foreign::new(*idx, owner);
+                let idx = idx.transfer_with(wctx, rctx, param_bind, event_bind);
+                idx.not(wctx)
+            }
+            Prop::And(lhs, rhs) => {
+                let lhs = Foreign::new(*lhs, owner);
+                let rhs = Foreign::new(*rhs, owner);
+                let lhs = lhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                let rhs = rhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                lhs.and(rhs, wctx)
+            }
+            Prop::Or(lhs, rhs) => {
+                let lhs = Foreign::new(*lhs, owner);
+                let rhs = Foreign::new(*rhs, owner);
+                let lhs = lhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                let rhs = rhs.transfer_with(wctx, rctx, param_bind, event_bind);
+                lhs.or(rhs, wctx)
+            }
+            Prop::Implies(prec, succ) => {
+                let prec = Foreign::new(*prec, owner);
+                let succ = Foreign::new(*succ, owner);
+                let prec =
+                    prec.transfer_with(wctx, rctx, param_bind, event_bind);
+                let succ =
+                    succ.transfer_with(wctx, rctx, param_bind, event_bind);
+                prec.implies(succ, wctx)
+            }
+        }
+    }
+}
+
+impl<C> Foreign<Time, C>
+where
+    C: Ctx<Time>
+        + Ctx<Expr>
+        + Ctx<Prop>
+        + Ctx<Param>
+        + Ctx<Event>
+        + AddCtx<Prop>
+        + AddCtx<Expr>
+        + AddCtx<Time>
+        + MutCtx<Param>,
+{
+    pub fn transfer_with(
+        &self,
+        wctx: &mut C,
+        rctx: &C,
+        param_bind: &Bind<Foreign<Param, C>, ExprIdx>,
+        event_bind: &Bind<Foreign<Event, C>, TimeIdx>,
+    ) -> TimeIdx {
+        let (e, owner) = self.take();
+        let Time { event, offset } = rctx.get(e);
+        let event = Foreign::new(*event, owner);
+        let offset = Foreign::new(*offset, owner);
+        let time = *event_bind.get(&event).unwrap();
+        let additional =
+            offset.transfer_with(wctx, rctx, param_bind, event_bind);
+
+        // Convert ['G + x] where 'G = 'H + y to ['H + x + y]
+
+        let Time { event, offset } = wctx.get(time).clone();
+        let offset = offset.add(additional, wctx);
+
+        wctx.add(Time { event, offset })
+    }
+}

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1872 @@
+warning: field `param_cons` is never read
+  --> crates/ir/src/from_ast/sig_map.rs:28:9
+   |
+13 | pub struct Sig {
+   |            --- field in this struct
+...
+28 |     pub param_cons: Vec<ast::Loc<ast::OrderConstraint<ast::Expr>>>,
+   |         ^^^^^^^^^^
+   |
+   = note: `Sig` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
+   = note: `#[warn(dead_code)]` on by default
+
+warning: `fil-ir` (lib) generated 1 warning
+   Compiling filament v0.1.0 (/home/filament/crates/filament)
+warning: unused imports: `Instance` and `self as ast`
+ --> crates/filament/src/ir_passes/assumptions.rs:2:15
+  |
+2 | use fil_ast::{self as ast, Instance};
+  |               ^^^^^^^^^^^  ^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused imports: `ExprIdx` and `PropIdx`
+ --> crates/filament/src/ir_passes/assumptions.rs:4:48
+  |
+4 |     self as ir, AddCtx, Bind, Ctx, DisplayCtx, ExprIdx, Foreign, PropIdx,
+  |                                                ^^^^^^^           ^^^^^^^
+
+warning: `filament` (lib) generated 2 warnings (run `cargo fix --lib -p filament` to apply 2 suggestions)
+warning: unreachable statement
+  --> crates/filament/src/main.rs:88:5
+   |
+87 |       std::process::exit(0);
+   |       --------------------- any code following this expression is unreachable
+88 | /     if !opts.unsafe_skip_discharge {
+89 | |         ir_pass_pipeline! {opts, ir; ip::Discharge }
+90 | |     }
+   | |_____^ unreachable statement
+   |
+   = note: `#[warn(unreachable_code)]` on by default
+
+warning: unused variable: `gen_exec`
+  --> crates/filament/src/main.rs:62:13
+   |
+62 |     let mut gen_exec = if ns.requires_gen() {
+   |             ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_gen_exec`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: variable does not need to be mutable
+  --> crates/filament/src/main.rs:62:9
+   |
+62 |     let mut gen_exec = if ns.requires_gen() {
+   |         ----^^^^^^^^
+   |         |
+   |         help: remove this `mut`
+   |
+   = note: `#[warn(unused_mut)]` on by default
+
+warning: `filament` (bin "filament") generated 3 warnings (run `cargo fix --bin "filament"` to apply 1 suggestion)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.17s
+     Running `target/debug/filament tests/check/exist-rec.fil --dump-after astconv --check --log trace --dump-after assumptions`
+[INFO ] Parsed `tests/check/exist-rec.fil` in 1ms
+[INFO ] Parsed `./primitives/core.fil` in 0ms
+[INFO ] Parsed `./primitives/./state.fil` in 3ms
+[INFO ] Parsed `./primitives/reshape.fil` in 5ms
+[INFO ] Parsed `./primitives/./comb.fil` in 9ms
+[TRACE] Imported: {
+        "/home/filament/primitives/core.fil",
+        "/home/filament/primitives/comb.fil",
+        "/home/filament/primitives/state.fil",
+        "/home/filament/primitives/reshape.fil",
+    }
+[TRACE] Components: [
+        "Serialize",
+        "Deserialize",
+        "Downsample",
+        "ConcatBundle",
+        "SplitWire",
+        "Shift",
+        "Pow",
+        "main",
+    ]
+[TRACE] Externs: [
+        "Register",
+        "Delay",
+        "PassThroughRegister",
+        "Prev",
+        "ContPrev",
+        "Const",
+        "Add",
+        "Sub",
+        "MultComb",
+        "And",
+        "Or",
+        "Xor",
+        "Not",
+        "Eq",
+        "Neq",
+        "Gt",
+        "Lt",
+        "Lte",
+        "Gte",
+        "SignExtend",
+        "ZeroExtend",
+        "Concat",
+        "Select",
+        "Slice",
+        "ReduceAnd",
+        "ReduceOr",
+        "ShiftLeft",
+        "ShiftRight",
+        "ArithShiftRight",
+        "Mux",
+        "Extend",
+    ]
+[INFO ] fsm-attributes: 0ms
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event L as %ev1
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[TRACE] Added event G as %ev0
+[DEBUG] Adding component: %comp0
+[DEBUG] Adding component: %comp1
+[DEBUG] Adding component: %comp2
+[DEBUG] Adding component: %comp3
+[DEBUG] Adding component: %comp4
+[DEBUG] Adding component: %comp5
+[DEBUG] Adding component: %comp6
+[DEBUG] Adding component: %comp7
+[DEBUG] Adding component: %comp8
+[DEBUG] Adding component: %comp9
+[DEBUG] Adding component: %comp10
+[DEBUG] Adding component: %comp11
+[DEBUG] Adding component: %comp12
+[DEBUG] Adding component: %comp13
+[DEBUG] Adding component: %comp14
+[DEBUG] Adding component: %comp15
+[DEBUG] Adding component: %comp16
+[DEBUG] Adding component: %comp17
+[DEBUG] Adding component: %comp18
+[DEBUG] Adding component: %comp19
+[DEBUG] Adding component: %comp20
+[DEBUG] Adding component: %comp21
+[DEBUG] Adding component: %comp22
+[DEBUG] Adding component: %comp23
+[DEBUG] Adding component: %comp24
+[DEBUG] Adding component: %comp25
+[DEBUG] Adding component: %comp26
+[DEBUG] Adding component: %comp27
+[DEBUG] Adding component: %comp28
+[DEBUG] Adding component: %comp29
+[DEBUG] Adding component: %comp30
+[DEBUG] Adding component: %comp31
+[DEBUG] Adding component: %comp32
+[DEBUG] Adding component: %comp33
+[DEBUG] Adding component: %comp34
+[DEBUG] Adding component: %comp35
+[DEBUG] Adding component: %comp36
+[DEBUG] Adding component: %comp37
+[DEBUG] Adding component: %comp38
+[INFO ] astconv: 8ms
+#[]
+ext comp Register[%pr0]<%ev0: |%ev1 - %ev0+1|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0+1, %ev1] %pr0) with {
+} where 
+  %ev1 > %ev0+1,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp Delay[%pr0]<%ev0: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0+1, %ev0+2] %pr0) with {
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp PassThroughRegister[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp Prev[%pr0, %pr1]<%ev0: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev0+1] %pr0) with {
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp ContPrev[%pr0, %pr1]<%ev0: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev0+1] %pr0) with {
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Const[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+) -> (
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp Add[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr4:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr1 >= %pr0,
+  %pr0 > 0,
+  %pr1 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+}
+#[]
+ext comp Sub[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr4:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr1 >= %pr0,
+  %pr0 > 0,
+  %pr1 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+}
+#[]
+ext comp MultComb[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr4:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr1 >= %pr0,
+  %pr0 > 0,
+  %pr1 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+}
+#[]
+ext comp And[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Or[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Xor[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Not[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp Eq[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Neq[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Gt[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Lt[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Lte[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Gte[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp SignExtend[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr1 >= %pr0,
+  %ev1 > %ev0,
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp ZeroExtend[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr1 >= %pr0,
+  %ev1 > %ev0,
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Concat[%pr0, %pr1, %pr2]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr3:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr4:1> [%ev0, %ev1] %pr1) -> (
+  #[]%p2: for<%pr5:1> [%ev0, %ev1] %pr2) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr2 == %pr0+%pr1,
+  %ev1 > %ev0,
+{
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+}
+#[]
+ext comp Select[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %pr0 > %pr1,
+  %ev1 > %ev0,
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Slice[%pr0, %pr1, %pr2, %pr3]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr4:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr5:1> [%ev0, %ev1] %pr3) with {
+} where 
+  %pr0 > 0,
+  %pr3 > 0,
+  %pr0 > %pr1,
+  %pr0 > %pr2,
+  %pr1 >= %pr2,
+  %pr3 == %pr1-%pr2+1,
+  %ev1 > %ev0,
+{
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+}
+#[]
+ext comp ReduceAnd[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp ReduceOr[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp ShiftLeft[%pr0, %pr1, %pr2]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr3:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr4:1> [%ev0, %ev1] %pr1) -> (
+  #[]%p2: for<%pr5:1> [%ev0, %ev1] %pr2) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr2 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+}
+#[]
+ext comp ShiftRight[%pr0, %pr1, %pr2]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr3:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr4:1> [%ev0, %ev1] %pr1) -> (
+  #[]%p2: for<%pr5:1> [%ev0, %ev1] %pr2) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr2 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+}
+#[]
+ext comp ArithShiftRight[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Mux[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] 1,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0,
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p3: for<%pr4:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+}
+#[]
+ext comp Extend[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %ev1 > %ev0,
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+comp %comp31[%pr0, %pr1, %pr2, %pr3, %pr4]<%ev0: %pr3*(%pr1-1)+%pr4>(
+  #[]%p0: for<%pr5:%pr1*%pr2> [%ev0, %ev0+%pr4] %pr0) -> (
+  #[]%p1: for<%pr6:%pr1, %pr7:%pr2> [%ev0+%pr3*%pr6, %ev0+%pr3*%pr6+%pr4] %pr0) with {
+} where 
+  %pr1 > 0,
+  %pr2 > 0,
+  %pr3 > 0,
+  %pr4 > 0,
+{
+  assume %pr5 >= 0 & %pr1*%pr2 > %pr5; // Misc
+  assume %pr6 >= 0 & %pr1 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr2 > %pr7; // Misc
+  assume %pr11 >= 0 & 1 > %pr11; // Misc
+  assume %pr12 >= 0 & 1 > %pr12; // Misc
+  for %pr8 in 0..%pr1 {
+    for %pr9 in 0..%pr2 {
+      let %pr10 = %pr2*%pr8+%pr9
+      if %pr8 > 0 {
+        %inst0 = Register[%pr0];
+        %inv0, %inv0.%p2, %inv0.%p3 = %inst0<%ev0, %ev0+%pr3*%pr8+%pr4>;
+        %inv0.%p3{0} = %p0{%pr10};
+        assert %pr3*%pr8+%pr4 > 1; // EventConstraint
+        %p1{%pr8}{%pr9} = %inv0.%p2{0};
+      } else {
+        %p1{%pr8}{%pr9} = %p0{%pr10};
+      }
+    }
+    assume %pr9 >= 0 & %pr2 > %pr9; // Misc
+  }
+  assume %pr8 >= 0 & %pr1 > %pr8; // Misc
+}
+#[]
+comp %comp32[%pr0, %pr1, %pr2, %pr3, %pr4]<%ev0: (%pr3*(%pr1-1)+%pr4)-1>(
+  #[]%p0: for<%pr5:%pr1, %pr6:%pr2> [%ev0+%pr3*%pr5, %ev0+%pr3*%pr5+%pr4] %pr0) -> (
+  #[]%p1: for<%pr7:%pr1*%pr2> [%ev0+%pr3*(%pr1-1), %ev0+%pr3*(%pr1-1)+%pr4] %pr0) with {
+} where 
+  %pr1 > 1,
+  %pr2 > 0,
+  %pr3 > 0,
+  %pr4 > 0,
+{
+  assume %pr5 >= 0 & %pr1 > %pr5; // Misc
+  assume %pr6 >= 0 & %pr2 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr1*%pr2 > %pr7; // Misc
+  assume %pr11 >= 0 & 1 > %pr11; // Misc
+  assume %pr12 >= 0 & 1 > %pr12; // Misc
+  for %pr8 in 0..%pr1 {
+    for %pr9 in 0..%pr2 {
+      let %pr10 = %pr2*%pr8+%pr9
+      if %pr1-1 > %pr8 {
+        %inst0 = Register[%pr0];
+        %inv0, %inv0.%p2, %inv0.%p3 = %inst0<%ev0+%pr3*%pr8, %ev0+%pr3*(%pr1-1)+%pr4>;
+        %inv0.%p3{0} = %p0{%pr8}{%pr9};
+        assert %pr3*(%pr1-1)+%pr4 > %pr3*%pr8+1; // EventConstraint
+        %p1{%pr10} = %inv0.%p2{0};
+      } else {
+        %p1{%pr10} = %p0{%pr8}{%pr9};
+      }
+    }
+    assume %pr9 >= 0 & %pr2 > %pr9; // Misc
+  }
+  assume %pr8 >= 0 & %pr1 > %pr8; // Misc
+}
+#[]
+comp %comp33[%pr0, %pr1, %pr2, %pr3]<%ev0: (%pr1-%pr0)*%pr2>(
+  #[]%p0: for<%pr4:%pr2> [%ev0+%pr0*%pr4, %ev0+%pr0*%pr4+1] %pr3) -> (
+  #[]%p1: for<%pr5:%pr2> [%ev0+%pr1*%pr5, %ev0+%pr1*%pr5+1] %pr3) with {
+} where 
+  %pr0 > 0,
+  %pr1 > %pr0,
+{
+  assume %pr4 >= 0 & %pr2 > %pr4; // Misc
+  assume %pr5 >= 0 & %pr2 > %pr5; // Misc
+  assume %pr7 >= 0 & 1 > %pr7; // Misc
+  assume %pr8 >= 0 & 1 > %pr8; // Misc
+  for %pr6 in 0..%pr2 {
+    if %pr6 == 0 {
+      %p1{%pr6} = %p0{%pr6};
+    } else {
+      %inst0 = Register[%pr3];
+      %inv0, %inv0.%p2, %inv0.%p3 = %inst0<%ev0+%pr0*%pr6, %ev0+%pr1*%pr6+1>;
+      %inv0.%p3{0} = %p0{%pr6};
+      assert %pr1*%pr6+1 > %pr0*%pr6+1; // EventConstraint
+      %p1{%pr6} = %inv0.%p2{0};
+    }
+  }
+  assume %pr6 >= 0 & %pr2 > %pr6; // Misc
+}
+#[]
+comp %comp34[%pr0, %pr1, %pr2]<%ev0: %pr2>(
+  #[]%p0: for<%pr3:%pr1> [%ev0, %ev0+%pr2] %pr0) -> (
+  #[]%p1: for<%pr4:1> [%ev0, %ev0+%pr2] %pr0*%pr1) with {
+} where 
+  %pr1 > 0,
+  %pr0 > 0,
+  %pr2 > 0,
+{
+  assume %pr3 >= 0 & %pr1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+  assume %pr6 >= 0 & 1 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr1-1 > %pr7; // Misc
+  assume %pr8 >= 0 & 1 > %pr8; // Misc
+  assume %pr9 >= 0 & 1 > %pr9; // Misc
+  if %pr1 == 1 {
+    %p1{0} = %p0{0};
+  } else {
+    %inst0 = comp34[%pr0, %pr1-1, %pr2];
+    %inv0, %inv0.%p2, %inv0.%p4 = %inst0<%ev0>;
+    %inv0.%p4{0..%pr1-1} = %p0{1..%pr1};
+    %inst1 = Concat[%pr0, %pr0*(%pr1-1), %pr0+%pr0*(%pr1-1)];
+    %inv1, %inv1.%p3, %inv1.%p5, %inv1.%p6 = %inst1<%ev0, %ev0+%pr2>;
+    %inv1.%p5{0} = %p0{0};
+    %inv1.%p6{0} = %inv0.%p2{0};
+    assert %pr2 > 0; // EventConstraint
+    %p1{0} = %inv1.%p3{0};
+  }
+}
+#[]
+comp %comp35[%pr0, %pr1, %pr2]<%ev0: %pr2>(
+  #[]%p0: for<%pr3:1> [%ev0, %ev0+%pr2] %pr0*%pr1) -> (
+  #[]%p1: for<%pr4:%pr1> [%ev0, %ev0+%pr2] %pr0) with {
+} where 
+  %pr1 > 0,
+  %pr0 > 0,
+  %pr2 > 0,
+{
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & %pr1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+  assume %pr6 >= 0 & 1 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr1-1 > %pr7; // Misc
+  assume %pr8 >= 0 & 1 > %pr8; // Misc
+  assume %pr9 >= 0 & 1 > %pr9; // Misc
+  assume %pr10 >= 0 & 1 > %pr10; // Misc
+  if %pr1 == 1 {
+    %p1{0} = %p0{0};
+  } else {
+    %inst0 = Slice[%pr0*%pr1, %pr0*%pr1-1, %pr0*(%pr1-1), %pr0*%pr1-1-%pr0*(%pr1-1)+1];
+    %inv0, %inv0.%p2, %inv0.%p5 = %inst0<%ev0, %ev0+%pr2>;
+    %inv0.%p5{0} = %p0{0};
+    assert %pr2 > 0; // EventConstraint
+    %p1{0} = %inv0.%p2{0};
+    %inst1 = Slice[%pr0*%pr1, %pr0*(%pr1-1)-1, 0, %pr0*(%pr1-1)-1+1];
+    %inv1, %inv1.%p3, %inv1.%p6 = %inst1<%ev0, %ev0+%pr2>;
+    %inv1.%p6{0} = %p0{0};
+    assert %pr2 > 0; // EventConstraint
+    %inst2 = comp35[%pr0, %pr1-1, %pr2];
+    %inv2, %inv2.%p4, %inv2.%p7 = %inst2<%ev0>;
+    %inv2.%p7{0} = %inv1.%p3{0};
+    %p1{1..%pr1} = %inv2.%p4{0..%pr1-1};
+  }
+}
+#[]
+comp %comp36[%pr0, %pr1, %pr2]<%ev0: 1>(
+  #[]%p0: for<%pr3:%pr2> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr4:%pr2> [%ev0+%pr1, %ev0+%pr1+1] %pr0) with {
+} where 
+  %pr0 > 0,
+{
+  assume %pr3 >= 0 & %pr2 > %pr3; // Misc
+  assume %pr4 >= 0 & %pr2 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+  assume %pr6 >= 0 & %pr2 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr2 > %pr7; // Misc
+  assume %pr8 >= 0 & %pr1+1 > %pr8; // Misc
+  assume %pr10 >= 0 & 1 > %pr10; // Misc
+  assume %pr11 >= 0 & 1 > %pr11; // Misc
+  assume %pr12 >= 0 & 1 > %pr12; // Misc
+  %inst0 = comp34[%pr0, %pr2, 1];
+  %inv0, %inv0.%p2, %inv0.%p4 = %inst0<%ev0>;
+  %inv0.%p4{0..%pr2} = %p0{0..%pr2};
+  %p5 = bundle for<%pr8:%pr1+1> [%ev0+%pr8, %ev0+%pr8+1] %pr0*%pr2;
+  %p5{0} = %inv0.%p2{0};
+  for %pr9 in 0..%pr1 {
+    %inst2 = Delay[%pr0*%pr2];
+    %inv2, %inv2.%p6, %inv2.%p7 = %inst2<%ev0+%pr9>;
+    %inv2.%p7{0} = %p5{%pr9};
+    %p5{%pr9+1} = %inv2.%p6{0};
+  }
+  assume %pr9 >= 0 & %pr1 > %pr9; // Misc
+  %inst1 = comp35[%pr0, %pr2, 1];
+  %inv1, %inv1.%p3, %inv1.%p8 = %inst1<%ev0+%pr1>;
+  %inv1.%p8{0} = %p5{%pr1};
+  %p1{0..%pr2} = %inv1.%p3{0..%pr2};
+}
+#[]
+comp %comp37[%pr0]<%ev0: 1>(
+) -> (
+) with {
+  exists %pr1 where %pr1 > 0;
+} where 
+  %pr0 >= 0,
+{
+  if %pr0 == 0 {
+    exists %pr1 = 1;
+  } else {
+    %inst0, %pr2 = comp37[%pr0-1];
+    assume %pr2 > 0; // ExistsConstraint
+    exists %pr1 = %pr2*2;
+  }
+}
+#[toplevel]
+comp main[]<%ev0: 1>(
+) -> (
+) with {
+{
+  %inst0, %pr0 = comp37[4];
+  assume %pr0 > 0; // ExistsConstraint
+  %inst1 = Add[%pr0, %pr0];
+}
+[TRACE] assumptions: Visiting component %comp0
+[TRACE] assumptions: Visiting component %comp1
+[TRACE] assumptions: Visiting component %comp2
+[TRACE] assumptions: Visiting component %comp3
+[TRACE] assumptions: Visiting component %comp4
+[TRACE] assumptions: Visiting component %comp5
+[TRACE] assumptions: Visiting component %comp6
+[TRACE] assumptions: Visiting component %comp7
+[TRACE] assumptions: Visiting component %comp8
+[TRACE] assumptions: Visiting component %comp9
+[TRACE] assumptions: Visiting component %comp10
+[TRACE] assumptions: Visiting component %comp11
+[TRACE] assumptions: Visiting component %comp12
+[TRACE] assumptions: Visiting component %comp13
+[TRACE] assumptions: Visiting component %comp14
+[TRACE] assumptions: Visiting component %comp15
+[TRACE] assumptions: Visiting component %comp16
+[TRACE] assumptions: Visiting component %comp17
+[TRACE] assumptions: Visiting component %comp18
+[TRACE] assumptions: Visiting component %comp19
+[TRACE] assumptions: Visiting component %comp20
+[TRACE] assumptions: Visiting component %comp21
+[TRACE] assumptions: Visiting component %comp22
+[TRACE] assumptions: Visiting component %comp23
+[TRACE] assumptions: Visiting component %comp24
+[TRACE] assumptions: Visiting component %comp25
+[TRACE] assumptions: Visiting component %comp26
+[TRACE] assumptions: Visiting component %comp27
+[TRACE] assumptions: Visiting component %comp28
+[TRACE] assumptions: Visiting component %comp29
+[TRACE] assumptions: Visiting component %comp30
+[TRACE] assumptions: Visiting component %comp31
+[TRACE] Transferring assumptions for instance %inst0 from comp %comp0 to %comp31
+[TRACE] assumptions: Visiting component %comp32
+[TRACE] Transferring assumptions for instance %inst0 from comp %comp0 to %comp32
+[TRACE] assumptions: Visiting component %comp33
+[TRACE] Transferring assumptions for instance %inst0 from comp %comp0 to %comp33
+[TRACE] assumptions: Visiting component %comp34
+[TRACE] Transferring assumptions for instance %inst0 from comp %comp34 to %comp34
+[TRACE] Transferring assumptions for instance %inst1 from comp %comp21 to %comp34
+[TRACE] Transferring parameter assumption %pr0 > 0 from %comp21 to %comp34
+[TRACE] Transferring parameter assumption %pr1 > 0 from %comp21 to %comp34
+[TRACE] Transferring parameter assumption %pr2 == %pr0+%pr1 from %comp21 to %comp34
+[TRACE] assumptions: Visiting component %comp35
+[TRACE] Transferring assumptions for instance %inst0 from comp %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr0 > 0 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr3 > 0 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr0 > %pr1 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr0 > %pr2 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr1 >= %pr2 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr3 == %pr1-%pr2+1 from %comp23 to %comp35
+[TRACE] Transferring assumptions for instance %inst1 from comp %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr0 > 0 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr3 > 0 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr0 > %pr1 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr0 > %pr2 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr1 >= %pr2 from %comp23 to %comp35
+[TRACE] Transferring parameter assumption %pr3 == %pr1-%pr2+1 from %comp23 to %comp35
+[TRACE] Transferring assumptions for instance %inst2 from comp %comp35 to %comp35
+[TRACE] assumptions: Visiting component %comp36
+[TRACE] Transferring assumptions for instance %inst0 from comp %comp34 to %comp36
+[TRACE] Transferring parameter assumption %pr1 > 0 from %comp34 to %comp36
+[TRACE] Transferring parameter assumption %pr0 > 0 from %comp34 to %comp36
+[TRACE] Transferring parameter assumption %pr2 > 0 from %comp34 to %comp36
+[TRACE] Transferring assumptions for instance %inst2 from comp %comp1 to %comp36
+[TRACE] Transferring assumptions for instance %inst1 from comp %comp35 to %comp36
+[TRACE] Transferring parameter assumption %pr1 > 0 from %comp35 to %comp36
+[TRACE] Transferring parameter assumption %pr0 > 0 from %comp35 to %comp36
+[TRACE] Transferring parameter assumption %pr2 > 0 from %comp35 to %comp36
+[TRACE] assumptions: Visiting component %comp37
+[TRACE] Transferring assumptions for instance %inst0 from comp %comp37 to %comp37
+[TRACE] assumptions: Visiting component %comp38
+[TRACE] Transferring assumptions for instance %inst0 from comp %comp37 to %comp38
+[TRACE] Transferring parameter assumption %pr0 >= 0 from %comp37 to %comp38
+[TRACE] Transferring existential assumption %pr1 > 0 from %comp37 to %comp38
+[TRACE] Transferring assumptions for instance %inst1 from comp %comp6 to %comp38
+[TRACE] Transferring parameter assumption %pr1 >= %pr0 from %comp6 to %comp38
+[TRACE] Transferring parameter assumption %pr0 > 0 from %comp6 to %comp38
+[TRACE] Transferring parameter assumption %pr1 > 0 from %comp6 to %comp38
+[INFO ] assumptions: 1ms
+#[]
+ext comp Register[%pr0]<%ev0: |%ev1 - %ev0+1|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0+1, %ev1] %pr0) with {
+} where 
+  %ev1 > %ev0+1,
+{
+  assume %ev1 > %ev0+1; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp Delay[%pr0]<%ev0: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0+1, %ev0+2] %pr0) with {
+{
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp PassThroughRegister[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp Prev[%pr0, %pr1]<%ev0: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev0+1] %pr0) with {
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp ContPrev[%pr0, %pr1]<%ev0: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev0+1] %pr0) with {
+{
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Const[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+) -> (
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp Add[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr4:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr1 >= %pr0,
+  %pr0 > 0,
+  %pr1 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr1 >= %pr0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+}
+#[]
+ext comp Sub[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr4:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr1 >= %pr0,
+  %pr0 > 0,
+  %pr1 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr1 >= %pr0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+}
+#[]
+ext comp MultComb[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr4:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr1 >= %pr0,
+  %pr0 > 0,
+  %pr1 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr1 >= %pr0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+}
+#[]
+ext comp And[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Or[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Xor[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Not[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp Eq[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Neq[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Gt[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Lt[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Lte[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Gte[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp SignExtend[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr1 >= %pr0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr1 >= %pr0; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp ZeroExtend[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr1 >= %pr0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr1 >= %pr0; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Concat[%pr0, %pr1, %pr2]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr3:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr4:1> [%ev0, %ev1] %pr1) -> (
+  #[]%p2: for<%pr5:1> [%ev0, %ev1] %pr2) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr2 == %pr0+%pr1,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr2 == %pr0+%pr1; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+}
+#[]
+ext comp Select[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %pr0 > %pr1,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr0 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Slice[%pr0, %pr1, %pr2, %pr3]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr4:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr5:1> [%ev0, %ev1] %pr3) with {
+} where 
+  %pr0 > 0,
+  %pr3 > 0,
+  %pr0 > %pr1,
+  %pr0 > %pr2,
+  %pr1 >= %pr2,
+  %pr3 == %pr1-%pr2+1,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr3 > 0; // Misc
+  assume %pr0 > %pr1; // Misc
+  assume %pr0 > %pr2; // Misc
+  assume %pr1 >= %pr2; // Misc
+  assume %pr3 == %pr1-%pr2+1; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+}
+#[]
+ext comp ReduceAnd[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp ReduceOr[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] 1) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+}
+#[]
+ext comp ShiftLeft[%pr0, %pr1, %pr2]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr3:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr4:1> [%ev0, %ev1] %pr1) -> (
+  #[]%p2: for<%pr5:1> [%ev0, %ev1] %pr2) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr2 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr2 > 0; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+}
+#[]
+ext comp ShiftRight[%pr0, %pr1, %pr2]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr3:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr4:1> [%ev0, %ev1] %pr1) -> (
+  #[]%p2: for<%pr5:1> [%ev0, %ev1] %pr2) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %pr2 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr2 > 0; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+}
+#[]
+ext comp ArithShiftRight[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] %pr0,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+ext comp Mux[%pr0]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr1:1> [%ev0, %ev1] 1,
+  #[]%p1: for<%pr2:1> [%ev0, %ev1] %pr0,
+  #[]%p2: for<%pr3:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p3: for<%pr4:1> [%ev0, %ev1] %pr0) with {
+} where 
+  %pr0 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 >= 0 & 1 > %pr1; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+}
+#[]
+ext comp Extend[%pr0, %pr1]<%ev0: |%ev1 - %ev0|, %ev1: 1>(
+  #[]%p0: for<%pr2:1> [%ev0, %ev1] %pr0) -> (
+  #[]%p1: for<%pr3:1> [%ev0, %ev1] %pr1) with {
+} where 
+  %pr0 > 0,
+  %pr1 > 0,
+  %ev1 > %ev0,
+{
+  assume %ev1 > %ev0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr1 > 0; // Misc
+  assume %pr2 >= 0 & 1 > %pr2; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+}
+#[]
+comp %comp31[%pr0, %pr1, %pr2, %pr3, %pr4]<%ev0: %pr3*(%pr1-1)+%pr4>(
+  #[]%p0: for<%pr5:%pr1*%pr2> [%ev0, %ev0+%pr4] %pr0) -> (
+  #[]%p1: for<%pr6:%pr1, %pr7:%pr2> [%ev0+%pr3*%pr6, %ev0+%pr3*%pr6+%pr4] %pr0) with {
+} where 
+  %pr1 > 0,
+  %pr2 > 0,
+  %pr3 > 0,
+  %pr4 > 0,
+{
+  assume %pr1 > 0; // Misc
+  assume %pr2 > 0; // Misc
+  assume %pr3 > 0; // Misc
+  assume %pr4 > 0; // Misc
+  assume %pr5 >= 0 & %pr1*%pr2 > %pr5; // Misc
+  assume %pr6 >= 0 & %pr1 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr2 > %pr7; // Misc
+  assume %pr11 >= 0 & 1 > %pr11; // Misc
+  assume %pr12 >= 0 & 1 > %pr12; // Misc
+  for %pr8 in 0..%pr1 {
+    for %pr9 in 0..%pr2 {
+      let %pr10 = %pr2*%pr8+%pr9
+      if %pr8 > 0 {
+        %inst0 = Register[%pr0];
+        %inv0, %inv0.%p2, %inv0.%p3 = %inst0<%ev0, %ev0+%pr3*%pr8+%pr4>;
+        %inv0.%p3{0} = %p0{%pr10};
+        assert %pr3*%pr8+%pr4 > 1; // EventConstraint
+        %p1{%pr8}{%pr9} = %inv0.%p2{0};
+      } else {
+        %p1{%pr8}{%pr9} = %p0{%pr10};
+      }
+    }
+    assume %pr9 >= 0 & %pr2 > %pr9; // Misc
+  }
+  assume %pr8 >= 0 & %pr1 > %pr8; // Misc
+}
+#[]
+comp %comp32[%pr0, %pr1, %pr2, %pr3, %pr4]<%ev0: (%pr3*(%pr1-1)+%pr4)-1>(
+  #[]%p0: for<%pr5:%pr1, %pr6:%pr2> [%ev0+%pr3*%pr5, %ev0+%pr3*%pr5+%pr4] %pr0) -> (
+  #[]%p1: for<%pr7:%pr1*%pr2> [%ev0+%pr3*(%pr1-1), %ev0+%pr3*(%pr1-1)+%pr4] %pr0) with {
+} where 
+  %pr1 > 1,
+  %pr2 > 0,
+  %pr3 > 0,
+  %pr4 > 0,
+{
+  assume %pr1 > 1; // Misc
+  assume %pr2 > 0; // Misc
+  assume %pr3 > 0; // Misc
+  assume %pr4 > 0; // Misc
+  assume %pr5 >= 0 & %pr1 > %pr5; // Misc
+  assume %pr6 >= 0 & %pr2 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr1*%pr2 > %pr7; // Misc
+  assume %pr11 >= 0 & 1 > %pr11; // Misc
+  assume %pr12 >= 0 & 1 > %pr12; // Misc
+  for %pr8 in 0..%pr1 {
+    for %pr9 in 0..%pr2 {
+      let %pr10 = %pr2*%pr8+%pr9
+      if %pr1-1 > %pr8 {
+        %inst0 = Register[%pr0];
+        %inv0, %inv0.%p2, %inv0.%p3 = %inst0<%ev0+%pr3*%pr8, %ev0+%pr3*(%pr1-1)+%pr4>;
+        %inv0.%p3{0} = %p0{%pr8}{%pr9};
+        assert %pr3*(%pr1-1)+%pr4 > %pr3*%pr8+1; // EventConstraint
+        %p1{%pr10} = %inv0.%p2{0};
+      } else {
+        %p1{%pr10} = %p0{%pr8}{%pr9};
+      }
+    }
+    assume %pr9 >= 0 & %pr2 > %pr9; // Misc
+  }
+  assume %pr8 >= 0 & %pr1 > %pr8; // Misc
+}
+#[]
+comp %comp33[%pr0, %pr1, %pr2, %pr3]<%ev0: (%pr1-%pr0)*%pr2>(
+  #[]%p0: for<%pr4:%pr2> [%ev0+%pr0*%pr4, %ev0+%pr0*%pr4+1] %pr3) -> (
+  #[]%p1: for<%pr5:%pr2> [%ev0+%pr1*%pr5, %ev0+%pr1*%pr5+1] %pr3) with {
+} where 
+  %pr0 > 0,
+  %pr1 > %pr0,
+{
+  assume %pr0 > 0; // Misc
+  assume %pr1 > %pr0; // Misc
+  assume %pr4 >= 0 & %pr2 > %pr4; // Misc
+  assume %pr5 >= 0 & %pr2 > %pr5; // Misc
+  assume %pr7 >= 0 & 1 > %pr7; // Misc
+  assume %pr8 >= 0 & 1 > %pr8; // Misc
+  for %pr6 in 0..%pr2 {
+    if %pr6 == 0 {
+      %p1{%pr6} = %p0{%pr6};
+    } else {
+      %inst0 = Register[%pr3];
+      %inv0, %inv0.%p2, %inv0.%p3 = %inst0<%ev0+%pr0*%pr6, %ev0+%pr1*%pr6+1>;
+      %inv0.%p3{0} = %p0{%pr6};
+      assert %pr1*%pr6+1 > %pr0*%pr6+1; // EventConstraint
+      %p1{%pr6} = %inv0.%p2{0};
+    }
+  }
+  assume %pr6 >= 0 & %pr2 > %pr6; // Misc
+}
+#[]
+comp %comp34[%pr0, %pr1, %pr2]<%ev0: %pr2>(
+  #[]%p0: for<%pr3:%pr1> [%ev0, %ev0+%pr2] %pr0) -> (
+  #[]%p1: for<%pr4:1> [%ev0, %ev0+%pr2] %pr0*%pr1) with {
+} where 
+  %pr1 > 0,
+  %pr0 > 0,
+  %pr2 > 0,
+{
+  assume %pr1 > 0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr2 > 0; // Misc
+  assume %pr3 >= 0 & %pr1 > %pr3; // Misc
+  assume %pr4 >= 0 & 1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+  assume %pr6 >= 0 & 1 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr1-1 > %pr7; // Misc
+  assume %pr8 >= 0 & 1 > %pr8; // Misc
+  assume %pr9 >= 0 & 1 > %pr9; // Misc
+  if %pr1 == 1 {
+    %p1{0} = %p0{0};
+  } else {
+    %inst0 = comp34[%pr0, %pr1-1, %pr2];
+    %inv0, %inv0.%p2, %inv0.%p4 = %inst0<%ev0>;
+    %inv0.%p4{0..%pr1-1} = %p0{1..%pr1};
+    assert %pr0 > 0; // ParamConstraint
+    assert %pr0*(%pr1-1) > 0; // ParamConstraint
+    assert %pr0+%pr0*(%pr1-1) == %pr0+%pr0*(%pr1-1); // ParamConstraint
+    %inst1 = Concat[%pr0, %pr0*(%pr1-1), %pr0+%pr0*(%pr1-1)];
+    %inv1, %inv1.%p3, %inv1.%p5, %inv1.%p6 = %inst1<%ev0, %ev0+%pr2>;
+    %inv1.%p5{0} = %p0{0};
+    %inv1.%p6{0} = %inv0.%p2{0};
+    assert %pr2 > 0; // EventConstraint
+    %p1{0} = %inv1.%p3{0};
+  }
+}
+#[]
+comp %comp35[%pr0, %pr1, %pr2]<%ev0: %pr2>(
+  #[]%p0: for<%pr3:1> [%ev0, %ev0+%pr2] %pr0*%pr1) -> (
+  #[]%p1: for<%pr4:%pr1> [%ev0, %ev0+%pr2] %pr0) with {
+} where 
+  %pr1 > 0,
+  %pr0 > 0,
+  %pr2 > 0,
+{
+  assume %pr1 > 0; // Misc
+  assume %pr0 > 0; // Misc
+  assume %pr2 > 0; // Misc
+  assume %pr3 >= 0 & 1 > %pr3; // Misc
+  assume %pr4 >= 0 & %pr1 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+  assume %pr6 >= 0 & 1 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr1-1 > %pr7; // Misc
+  assume %pr8 >= 0 & 1 > %pr8; // Misc
+  assume %pr9 >= 0 & 1 > %pr9; // Misc
+  assume %pr10 >= 0 & 1 > %pr10; // Misc
+  if %pr1 == 1 {
+    %p1{0} = %p0{0};
+  } else {
+    assert %pr0*%pr1 > 0; // ParamConstraint
+    assert %pr0*%pr1-1-%pr0*(%pr1-1)+1 > 0; // ParamConstraint
+    assert %pr0*%pr1 > %pr0*%pr1-1; // ParamConstraint
+    assert %pr0*%pr1 > %pr0*(%pr1-1); // ParamConstraint
+    assert %pr0*%pr1-1 >= %pr0*(%pr1-1); // ParamConstraint
+    assert %pr0*%pr1-1-%pr0*(%pr1-1)+1 == %pr0*%pr1-1-%pr0*(%pr1-1)+1; // ParamConstraint
+    %inst0 = Slice[%pr0*%pr1, %pr0*%pr1-1, %pr0*(%pr1-1), %pr0*%pr1-1-%pr0*(%pr1-1)+1];
+    %inv0, %inv0.%p2, %inv0.%p5 = %inst0<%ev0, %ev0+%pr2>;
+    %inv0.%p5{0} = %p0{0};
+    assert %pr2 > 0; // EventConstraint
+    %p1{0} = %inv0.%p2{0};
+    assert %pr0*%pr1 > 0; // ParamConstraint
+    assert %pr0*(%pr1-1)-1+1 > 0; // ParamConstraint
+    assert %pr0*%pr1 > %pr0*(%pr1-1)-1; // ParamConstraint
+    assert %pr0*%pr1 > 0; // ParamConstraint
+    assert %pr0*(%pr1-1)-1 >= 0; // ParamConstraint
+    assert %pr0*(%pr1-1)-1+1 == %pr0*(%pr1-1)-1+1; // ParamConstraint
+    %inst1 = Slice[%pr0*%pr1, %pr0*(%pr1-1)-1, 0, %pr0*(%pr1-1)-1+1];
+    %inv1, %inv1.%p3, %inv1.%p6 = %inst1<%ev0, %ev0+%pr2>;
+    %inv1.%p6{0} = %p0{0};
+    assert %pr2 > 0; // EventConstraint
+    %inst2 = comp35[%pr0, %pr1-1, %pr2];
+    %inv2, %inv2.%p4, %inv2.%p7 = %inst2<%ev0>;
+    %inv2.%p7{0} = %inv1.%p3{0};
+    %p1{1..%pr1} = %inv2.%p4{0..%pr1-1};
+  }
+}
+#[]
+comp %comp36[%pr0, %pr1, %pr2]<%ev0: 1>(
+  #[]%p0: for<%pr3:%pr2> [%ev0, %ev0+1] %pr0) -> (
+  #[]%p1: for<%pr4:%pr2> [%ev0+%pr1, %ev0+%pr1+1] %pr0) with {
+} where 
+  %pr0 > 0,
+{
+  assume %pr0 > 0; // Misc
+  assume %pr3 >= 0 & %pr2 > %pr3; // Misc
+  assume %pr4 >= 0 & %pr2 > %pr4; // Misc
+  assume %pr5 >= 0 & 1 > %pr5; // Misc
+  assume %pr6 >= 0 & %pr2 > %pr6; // Misc
+  assume %pr7 >= 0 & %pr2 > %pr7; // Misc
+  assume %pr8 >= 0 & %pr1+1 > %pr8; // Misc
+  assume %pr10 >= 0 & 1 > %pr10; // Misc
+  assume %pr11 >= 0 & 1 > %pr11; // Misc
+  assume %pr12 >= 0 & 1 > %pr12; // Misc
+  assert %pr2 > 0; // ParamConstraint
+  assert %pr0 > 0; // ParamConstraint
+  %inst0 = comp34[%pr0, %pr2, 1];
+  %inv0, %inv0.%p2, %inv0.%p4 = %inst0<%ev0>;
+  %inv0.%p4{0..%pr2} = %p0{0..%pr2};
+  %p5 = bundle for<%pr8:%pr1+1> [%ev0+%pr8, %ev0+%pr8+1] %pr0*%pr2;
+  %p5{0} = %inv0.%p2{0};
+  for %pr9 in 0..%pr1 {
+    %inst2 = Delay[%pr0*%pr2];
+    %inv2, %inv2.%p6, %inv2.%p7 = %inst2<%ev0+%pr9>;
+    %inv2.%p7{0} = %p5{%pr9};
+    %p5{%pr9+1} = %inv2.%p6{0};
+  }
+  assume %pr9 >= 0 & %pr1 > %pr9; // Misc
+  assert %pr2 > 0; // ParamConstraint
+  assert %pr0 > 0; // ParamConstraint
+  %inst1 = comp35[%pr0, %pr2, 1];
+  %inv1, %inv1.%p3, %inv1.%p8 = %inst1<%ev0+%pr1>;
+  %inv1.%p8{0} = %p5{%pr1};
+  %p1{0..%pr2} = %inv1.%p3{0..%pr2};
+}
+#[]
+comp %comp37[%pr0]<%ev0: 1>(
+) -> (
+) with {
+  exists %pr1 where %pr1 > 0;
+} where 
+  %pr0 >= 0,
+{
+  assume %pr0 >= 0; // Misc
+  if %pr0 == 0 {
+    exists %pr1 = 1;
+  } else {
+    %inst0, %pr2 = comp37[%pr0-1];
+    assume %pr2 > 0; // ExistsConstraint
+    exists %pr1 = %pr2*2;
+  }
+}
+#[toplevel]
+comp main[]<%ev0: 1>(
+) -> (
+) with {
+{
+  assume %pr0 > 0; // ExistsConstraint
+  %inst0, %pr0 = comp37[4];
+  assume %pr0 > 0; // ExistsConstraint
+  assert %pr0 >= %pr0; // ParamConstraint
+  assert %pr0 > 0; // ParamConstraint
+  assert %pr0 > 0; // ParamConstraint
+  %inst1 = Add[%pr0, %pr0];
+}
+[TRACE] build-domination: Visiting component %comp0
+[TRACE] build-domination: Visiting component %comp1
+[TRACE] build-domination: Visiting component %comp2
+[TRACE] build-domination: Visiting component %comp3
+[TRACE] build-domination: Visiting component %comp4
+[TRACE] build-domination: Visiting component %comp5
+[TRACE] build-domination: Visiting component %comp6
+[TRACE] build-domination: Visiting component %comp7
+[TRACE] build-domination: Visiting component %comp8
+[TRACE] build-domination: Visiting component %comp9
+[TRACE] build-domination: Visiting component %comp10
+[TRACE] build-domination: Visiting component %comp11
+[TRACE] build-domination: Visiting component %comp12
+[TRACE] build-domination: Visiting component %comp13
+[TRACE] build-domination: Visiting component %comp14
+[TRACE] build-domination: Visiting component %comp15
+[TRACE] build-domination: Visiting component %comp16
+[TRACE] build-domination: Visiting component %comp17
+[TRACE] build-domination: Visiting component %comp18
+[TRACE] build-domination: Visiting component %comp19
+[TRACE] build-domination: Visiting component %comp20
+[TRACE] build-domination: Visiting component %comp21
+[TRACE] build-domination: Visiting component %comp22
+[TRACE] build-domination: Visiting component %comp23
+[TRACE] build-domination: Visiting component %comp24
+[TRACE] build-domination: Visiting component %comp25
+[TRACE] build-domination: Visiting component %comp26
+[TRACE] build-domination: Visiting component %comp27
+[TRACE] build-domination: Visiting component %comp28
+[TRACE] build-domination: Visiting component %comp29
+[TRACE] build-domination: Visiting component %comp30
+[TRACE] build-domination: Visiting component %comp31
+[TRACE] param %pr0 is used by %inst0
+[TRACE] let-bound param %pr10
+[TRACE] param %pr2 is used by %pr10
+[TRACE] param %pr8 is used by %pr10
+[TRACE] param %pr9 is used by %pr10
+[TRACE] build-domination: Visiting component %comp32
+[TRACE] param %pr0 is used by %inst0
+[TRACE] let-bound param %pr10
+[TRACE] param %pr2 is used by %pr10
+[TRACE] param %pr8 is used by %pr10
+[TRACE] param %pr9 is used by %pr10
+[TRACE] build-domination: Visiting component %comp33
+[TRACE] param %pr3 is used by %inst0
+[TRACE] build-domination: Visiting component %comp34
+[TRACE] param %pr0 is used by %inst0
+[TRACE] param %pr1 is used by %inst0
+[TRACE] param %pr2 is used by %inst0
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr1 is used by %inst1
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr1 is used by %inst1
+[TRACE] build-domination: Visiting component %comp35
+[TRACE] param %pr0 is used by %inst0
+[TRACE] param %pr1 is used by %inst0
+[TRACE] param %pr0 is used by %inst0
+[TRACE] param %pr1 is used by %inst0
+[TRACE] param %pr0 is used by %inst0
+[TRACE] param %pr1 is used by %inst0
+[TRACE] param %pr0 is used by %inst0
+[TRACE] param %pr1 is used by %inst0
+[TRACE] param %pr0 is used by %inst0
+[TRACE] param %pr1 is used by %inst0
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr1 is used by %inst1
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr1 is used by %inst1
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr1 is used by %inst1
+[TRACE] param %pr0 is used by %inst2
+[TRACE] param %pr1 is used by %inst2
+[TRACE] param %pr2 is used by %inst2
+[TRACE] build-domination: Visiting component %comp36
+[TRACE] param %pr0 is used by %inst2
+[TRACE] param %pr2 is used by %inst2
+[TRACE] param %pr0 is used by %inst0
+[TRACE] param %pr2 is used by %inst0
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr2 is used by %inst1
+[TRACE] build-domination: Visiting component %comp37
+[TRACE] param %pr2 is owned by %inst0
+[TRACE] param %pr0 is used by %inst0
+[TRACE] build-domination: Visiting component %comp38
+[TRACE] param %pr0 is owned by %inst0
+[TRACE] param %pr0 is used by %inst1
+[TRACE] param %pr0 is used by %inst1
+[INFO ] build-domination: 0ms
+[TRACE] type-check: Visiting component %comp0
+[TRACE] type-check: Visiting component %comp1
+[TRACE] type-check: Visiting component %comp2
+[TRACE] type-check: Visiting component %comp3
+[TRACE] type-check: Visiting component %comp4
+[TRACE] type-check: Visiting component %comp5
+[TRACE] type-check: Visiting component %comp6
+[TRACE] type-check: Visiting component %comp7
+[TRACE] type-check: Visiting component %comp8
+[TRACE] type-check: Visiting component %comp9
+[TRACE] type-check: Visiting component %comp10
+[TRACE] type-check: Visiting component %comp11
+[TRACE] type-check: Visiting component %comp12
+[TRACE] type-check: Visiting component %comp13
+[TRACE] type-check: Visiting component %comp14
+[TRACE] type-check: Visiting component %comp15
+[TRACE] type-check: Visiting component %comp16
+[TRACE] type-check: Visiting component %comp17
+[TRACE] type-check: Visiting component %comp18
+[TRACE] type-check: Visiting component %comp19
+[TRACE] type-check: Visiting component %comp20
+[TRACE] type-check: Visiting component %comp21
+[TRACE] type-check: Visiting component %comp22
+[TRACE] type-check: Visiting component %comp23
+[TRACE] type-check: Visiting component %comp24
+[TRACE] type-check: Visiting component %comp25
+[TRACE] type-check: Visiting component %comp26
+[TRACE] type-check: Visiting component %comp27
+[TRACE] type-check: Visiting component %comp28
+[TRACE] type-check: Visiting component %comp29
+[TRACE] type-check: Visiting component %comp30
+[TRACE] type-check: Visiting component %comp31
+[TRACE] type-check: Visiting component %comp32
+[TRACE] type-check: Visiting component %comp33
+[TRACE] type-check: Visiting component %comp34
+[TRACE] type-check: Visiting component %comp35
+[TRACE] type-check: Visiting component %comp36
+[TRACE] type-check: Visiting component %comp37
+[TRACE] type-check: Visiting component %comp38
+[INFO ] type-check: 1ms
+[TRACE] interval-check: Visiting component %comp0
+[TRACE] interval-check: Visiting component %comp1
+[TRACE] interval-check: Visiting component %comp2
+[TRACE] interval-check: Visiting component %comp3
+[TRACE] interval-check: Visiting component %comp4
+[TRACE] interval-check: Visiting component %comp5
+[TRACE] interval-check: Visiting component %comp6
+[TRACE] interval-check: Visiting component %comp7
+[TRACE] interval-check: Visiting component %comp8
+[TRACE] interval-check: Visiting component %comp9
+[TRACE] interval-check: Visiting component %comp10
+[TRACE] interval-check: Visiting component %comp11
+[TRACE] interval-check: Visiting component %comp12
+[TRACE] interval-check: Visiting component %comp13
+[TRACE] interval-check: Visiting component %comp14
+[TRACE] interval-check: Visiting component %comp15
+[TRACE] interval-check: Visiting component %comp16
+[TRACE] interval-check: Visiting component %comp17
+[TRACE] interval-check: Visiting component %comp18
+[TRACE] interval-check: Visiting component %comp19
+[TRACE] interval-check: Visiting component %comp20
+[TRACE] interval-check: Visiting component %comp21
+[TRACE] interval-check: Visiting component %comp22
+[TRACE] interval-check: Visiting component %comp23
+[TRACE] interval-check: Visiting component %comp24
+[TRACE] interval-check: Visiting component %comp25
+[TRACE] interval-check: Visiting component %comp26
+[TRACE] interval-check: Visiting component %comp27
+[TRACE] interval-check: Visiting component %comp28
+[TRACE] interval-check: Visiting component %comp29
+[TRACE] interval-check: Visiting component %comp30
+[TRACE] interval-check: Visiting component %comp31
+[TRACE] interval-check: Visiting component %comp32
+[TRACE] interval-check: Visiting component %comp33
+[TRACE] interval-check: Visiting component %comp34
+[TRACE] interval-check: Visiting component %comp35
+[TRACE] interval-check: Visiting component %comp36
+[TRACE] interval-check: Visiting component %comp37
+[TRACE] interval-check: Visiting component %comp38
+[INFO ] interval-check: 2ms
+[TRACE] phantom-check: Visiting component %comp0
+[TRACE] phantom-check: Visiting component %comp1
+[TRACE] phantom-check: Visiting component %comp2
+[TRACE] phantom-check: Visiting component %comp3
+[TRACE] phantom-check: Visiting component %comp4
+[TRACE] phantom-check: Visiting component %comp5
+[TRACE] phantom-check: Visiting component %comp6
+[TRACE] phantom-check: Visiting component %comp7
+[TRACE] phantom-check: Visiting component %comp8
+[TRACE] phantom-check: Visiting component %comp9
+[TRACE] phantom-check: Visiting component %comp10
+[TRACE] phantom-check: Visiting component %comp11
+[TRACE] phantom-check: Visiting component %comp12
+[TRACE] phantom-check: Visiting component %comp13
+[TRACE] phantom-check: Visiting component %comp14
+[TRACE] phantom-check: Visiting component %comp15
+[TRACE] phantom-check: Visiting component %comp16
+[TRACE] phantom-check: Visiting component %comp17
+[TRACE] phantom-check: Visiting component %comp18
+[TRACE] phantom-check: Visiting component %comp19
+[TRACE] phantom-check: Visiting component %comp20
+[TRACE] phantom-check: Visiting component %comp21
+[TRACE] phantom-check: Visiting component %comp22
+[TRACE] phantom-check: Visiting component %comp23
+[TRACE] phantom-check: Visiting component %comp24
+[TRACE] phantom-check: Visiting component %comp25
+[TRACE] phantom-check: Visiting component %comp26
+[TRACE] phantom-check: Visiting component %comp27
+[TRACE] phantom-check: Visiting component %comp28
+[TRACE] phantom-check: Visiting component %comp29
+[TRACE] phantom-check: Visiting component %comp30
+[TRACE] phantom-check: Visiting component %comp31
+[TRACE] phantom-check: Visiting component %comp32
+[TRACE] phantom-check: Visiting component %comp33
+[TRACE] phantom-check: Visiting component %comp34
+[TRACE] phantom-check: Visiting component %comp35
+[TRACE] phantom-check: Visiting component %comp36
+[TRACE] phantom-check: Visiting component %comp37
+[TRACE] phantom-check: Visiting component %comp38
+[INFO ] phantom-check: 0ms
+[TRACE] fun-assumptions: Visiting component %comp0
+[TRACE] fun-assumptions: Visiting component %comp1
+[TRACE] fun-assumptions: Visiting component %comp2
+[TRACE] fun-assumptions: Visiting component %comp3
+[TRACE] fun-assumptions: Visiting component %comp4
+[TRACE] fun-assumptions: Visiting component %comp5
+[TRACE] fun-assumptions: Visiting component %comp6
+[TRACE] fun-assumptions: Visiting component %comp7
+[TRACE] fun-assumptions: Visiting component %comp8
+[TRACE] fun-assumptions: Visiting component %comp9
+[TRACE] fun-assumptions: Visiting component %comp10
+[TRACE] fun-assumptions: Visiting component %comp11
+[TRACE] fun-assumptions: Visiting component %comp12
+[TRACE] fun-assumptions: Visiting component %comp13
+[TRACE] fun-assumptions: Visiting component %comp14
+[TRACE] fun-assumptions: Visiting component %comp15
+[TRACE] fun-assumptions: Visiting component %comp16
+[TRACE] fun-assumptions: Visiting component %comp17
+[TRACE] fun-assumptions: Visiting component %comp18
+[TRACE] fun-assumptions: Visiting component %comp19
+[TRACE] fun-assumptions: Visiting component %comp20
+[TRACE] fun-assumptions: Visiting component %comp21
+[TRACE] fun-assumptions: Visiting component %comp22
+[TRACE] fun-assumptions: Visiting component %comp23
+[TRACE] fun-assumptions: Visiting component %comp24
+[TRACE] fun-assumptions: Visiting component %comp25
+[TRACE] fun-assumptions: Visiting component %comp26
+[TRACE] fun-assumptions: Visiting component %comp27
+[TRACE] fun-assumptions: Visiting component %comp28
+[TRACE] fun-assumptions: Visiting component %comp29
+[TRACE] fun-assumptions: Visiting component %comp30
+[TRACE] fun-assumptions: Visiting component %comp31
+[TRACE] fun-assumptions: Visiting component %comp32
+[TRACE] fun-assumptions: Visiting component %comp33
+[TRACE] fun-assumptions: Visiting component %comp34
+[TRACE] fun-assumptions: Visiting component %comp35
+[TRACE] fun-assumptions: Visiting component %comp36
+[TRACE] fun-assumptions: Visiting component %comp37
+[TRACE] fun-assumptions: Visiting component %comp38
+[INFO ] fun-assumptions: 0ms

--- a/tests/check/exist-assertions.fil
+++ b/tests/check/exist-assertions.fil
@@ -1,0 +1,5 @@
+comp main<'G: 1>() -> () with {
+    some L where L >= 0;
+} where L >= 0 {
+    L := 1;
+}


### PR DESCRIPTION
This PR divests core assumption/assertion generation (about event constraints, param constraints, and range constraints) from astconv. This cleans up astconv a bit and also adds the important ability for the IR to generate its own assertions necessary for discharging. This will be useful in scheduling and is also necessary if we want to be able to discharge after monomorphization properly.