### PR TITLE
Fix getting started instructions

### DIFF
--- a/doc/docs/start.md
+++ b/doc/docs/start.md
@@ -17,7 +17,7 @@ Next, we can install the dependencies for the Filament compiler:
 
 To check that the compiler works, run the following command:
 ```
-cargo run -- tests/compile/par.fil
+cargo run -- tests/run/add.fil
 ```
 Which should generate the Verilog implementing the original program.
 


### PR DESCRIPTION
The instruction suggest using a file that no longer exists. I tested this file and it works.

Fixes #451