### PR TITLE
Fix link in Getting Started docs

### DIFF
--- a/doc/docs/start.md
+++ b/doc/docs/start.md
@@ -32,7 +32,7 @@ Calyx tools are provided using a docker image:
 docker run -it ghcr.io/cucapra/calyx:0.4.0
 ```
 
-If you're using the container, skip to [configuring Filament tools][#configuring-filament-tools].
+If you're using the container, skip to [configuring Filament tools](#configuring-filament-tools).
 
 ### Installing from Source
 


### PR DESCRIPTION
Fix markdown link syntax.