### PR TITLE
Update CLI opts

### DIFF
--- a/crates/filament/src/cmdline.rs
+++ b/crates/filament/src/cmdline.rs
@@ -57,6 +57,10 @@ pub struct Opts {
     #[argh(option, long = "dump-after")]
     pub dump_after: Vec<String>,
 
+    /// print out the IR after every pass
+    #[argh(switch, long = "dump-all")]
+    pub dump_all: bool,
+
     /// print out assignments that falsify the constraints
     #[argh(switch, long = "show-models")]
     pub show_models: bool,
@@ -100,15 +104,17 @@ pub struct Opts {
     /// backend to use (default: verilog): calyx, verilog
     #[argh(option, long = "backend", default = "Backend::Verilog")]
     pub backend: Backend,
+
     /// disable generation of counter-based FSMs in the backend.
     /// The default (non-counter) FSM is represented by a single bit Shift Register counting through the number of states.
     /// However, for components with a large number of states or a large II, it may be more efficient to use a counter-based FSM,
     /// where one counter loops every II states, at which point it increments the state counter.
     #[argh(switch, long = "no-counter-fsms")]
     pub no_counter_fsms: bool,
-    /// preserves original port names during compilation.
-    #[argh(switch, long = "preserve-names")]
-    pub preserve_names: bool,
+
+    /// do not preserve original port names during compilation.
+    #[argh(switch, long = "no-preserve-names")]
+    pub no_preserve_names: bool,
 
     // Solver specific configuration
     /// solver to use (default: cvc5): cvc5, z3

--- a/crates/filament/src/macros.rs
+++ b/crates/filament/src/macros.rs
@@ -64,7 +64,8 @@ macro_rules! ir_pass_pipeline {
         $(
             let name = <$pass as $crate::ir_visitor::Visitor>::name();
             $crate::log_time!(<$pass as $crate::ir_visitor::Visitor>::do_pass($opts, &mut $ir)?, name);
-            if $opts.dump_after.contains(&name.to_string()) {
+            if $opts.dump_after.contains(&name.to_string()) || $opts.dump_all {
+                println!("=== After pass: {} ===", name);
                 ::fil_ir::Printer::context(& $ir, &mut std::io::stdout()).unwrap()
             }
         )*

--- a/crates/filament/src/main.rs
+++ b/crates/filament/src/main.rs
@@ -122,7 +122,7 @@ fn run(opts: &cmdline::Opts) -> Result<(), u64> {
         return Ok(());
     }
     let calyx =
-        log_time!(ip::Compile::compile(ir, opts.preserve_names), "compile");
+        log_time!(ip::Compile::compile(ir, !opts.no_preserve_names), "compile");
     match opts.backend {
         cmdline::Backend::Verilog => {
             gen_verilog(calyx).unwrap();


### PR DESCRIPTION
Add `--dump-all` to dump the state of the AST after every pass and invert the `preserve-names` option.